### PR TITLE
feat(mcp): SessionStore abstraction with InMemory and Redis backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 The following changes are not yet released, but are code complete:
 
 Features:
--
+- Add session abstraction for MCP server and implement in-memory and redis-based sessions.
 
 Changes:
 -

--- a/courtlistener/mcp/session.py
+++ b/courtlistener/mcp/session.py
@@ -15,14 +15,10 @@ class SessionStore(ABC):
         return uuid.uuid4().hex[:8]
 
     @abstractmethod
-    def store_query(
-        self, user_id: str, query_id: str, data: dict
-    ) -> None: ...
+    def store_query(self, user_id: str, query_id: str, data: dict) -> None: ...
 
     @abstractmethod
-    def get_query(
-        self, user_id: str, query_id: str
-    ) -> dict | None: ...
+    def get_query(self, user_id: str, query_id: str) -> dict | None: ...
 
     @abstractmethod
     def store_citation_analysis(
@@ -53,14 +49,10 @@ class InMemorySessionStore(SessionStore):
     def __init__(self) -> None:
         self._data: dict[str, dict] = {}
 
-    def store_query(
-        self, user_id: str, query_id: str, data: dict
-    ) -> None:
+    def store_query(self, user_id: str, query_id: str, data: dict) -> None:
         self._data[f"{user_id}:query:{query_id}"] = data
 
-    def get_query(
-        self, user_id: str, query_id: str
-    ) -> dict | None:
+    def get_query(self, user_id: str, query_id: str) -> dict | None:
         return self._data.get(f"{user_id}:query:{query_id}")
 
     def store_citation_analysis(
@@ -68,9 +60,7 @@ class InMemorySessionStore(SessionStore):
     ) -> None:
         self._data[f"{user_id}:citation:{job_id}"] = data
 
-    def get_citation_analysis(
-        self, user_id: str, job_id: str
-    ) -> dict | None:
+    def get_citation_analysis(self, user_id: str, job_id: str) -> dict | None:
         return self._data.get(f"{user_id}:citation:{job_id}")
 
 
@@ -88,15 +78,11 @@ class RedisSessionStore(SessionStore):
     def __init__(self, redis_client: Any) -> None:
         self._redis = redis_client
 
-    def store_query(
-        self, user_id: str, query_id: str, data: dict
-    ) -> None:
+    def store_query(self, user_id: str, query_id: str, data: dict) -> None:
         key = f"mcp:{user_id}:query:{query_id}"
         self._redis.set(key, json.dumps(data), ex=self.QUERY_TTL)
 
-    def get_query(
-        self, user_id: str, query_id: str
-    ) -> dict | None:
+    def get_query(self, user_id: str, query_id: str) -> dict | None:
         key = f"mcp:{user_id}:query:{query_id}"
         raw = self._redis.get(key)
         return json.loads(raw) if raw else None
@@ -105,13 +91,9 @@ class RedisSessionStore(SessionStore):
         self, user_id: str, job_id: str, data: dict
     ) -> None:
         key = f"mcp:{user_id}:citation:{job_id}"
-        self._redis.set(
-            key, json.dumps(data), ex=self.CITATION_TTL
-        )
+        self._redis.set(key, json.dumps(data), ex=self.CITATION_TTL)
 
-    def get_citation_analysis(
-        self, user_id: str, job_id: str
-    ) -> dict | None:
+    def get_citation_analysis(self, user_id: str, job_id: str) -> dict | None:
         key = f"mcp:{user_id}:citation:{job_id}"
         raw = self._redis.get(key)
         return json.loads(raw) if raw else None

--- a/courtlistener/mcp/session.py
+++ b/courtlistener/mcp/session.py
@@ -4,7 +4,11 @@ import hashlib
 import json
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from redis import Redis
 
 
 class SessionStore(ABC):
@@ -50,7 +54,7 @@ class InMemorySessionStore(SessionStore):
         self._data: dict[str, dict] = {}
 
     def store_query(self, user_id: str, query_id: str, data: dict) -> None:
-        self._data[f"{user_id}:query:{query_id}"] = data
+        self._data[f"{user_id}:query:{query_id}"] = deepcopy(data)
 
     def get_query(self, user_id: str, query_id: str) -> dict | None:
         return self._data.get(f"{user_id}:query:{query_id}")
@@ -75,7 +79,7 @@ class RedisSessionStore(SessionStore):
     QUERY_TTL = 3600  # 1 hour
     CITATION_TTL = 7200  # 2 hours
 
-    def __init__(self, redis_client: Any) -> None:
+    def __init__(self, redis_client: Redis) -> None:
         self._redis = redis_client
 
     def store_query(self, user_id: str, query_id: str, data: dict) -> None:

--- a/courtlistener/mcp/session.py
+++ b/courtlistener/mcp/session.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class SessionStore(ABC):
+    """Abstraction over session state storage."""
+
+    def make_id(self) -> str:
+        """Generate a short UUID for a new query/job."""
+        return uuid.uuid4().hex[:8]
+
+    @abstractmethod
+    def store_query(
+        self, user_id: str, query_id: str, data: dict
+    ) -> None: ...
+
+    @abstractmethod
+    def get_query(
+        self, user_id: str, query_id: str
+    ) -> dict | None: ...
+
+    @abstractmethod
+    def store_citation_analysis(
+        self, user_id: str, job_id: str, data: dict
+    ) -> None: ...
+
+    @abstractmethod
+    def get_citation_analysis(
+        self, user_id: str, job_id: str
+    ) -> dict | None: ...
+
+    @staticmethod
+    def hash_token(token: str) -> str:
+        """Derive a user identifier from an API token.
+
+        Returns a 16-char hex string (truncated SHA-256). Never store
+        the raw token — only this hash is used as a Redis key prefix.
+        """
+        return hashlib.sha256(token.encode()).hexdigest()[:16]
+
+
+class InMemorySessionStore(SessionStore):
+    """Dict-backed store for stdio mode (single user, single process).
+
+    Not thread-safe — suitable for single-process stdio servers only.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[str, dict] = {}
+
+    def store_query(
+        self, user_id: str, query_id: str, data: dict
+    ) -> None:
+        self._data[f"{user_id}:query:{query_id}"] = data
+
+    def get_query(
+        self, user_id: str, query_id: str
+    ) -> dict | None:
+        return self._data.get(f"{user_id}:query:{query_id}")
+
+    def store_citation_analysis(
+        self, user_id: str, job_id: str, data: dict
+    ) -> None:
+        self._data[f"{user_id}:citation:{job_id}"] = data
+
+    def get_citation_analysis(
+        self, user_id: str, job_id: str
+    ) -> dict | None:
+        return self._data.get(f"{user_id}:citation:{job_id}")
+
+
+class RedisSessionStore(SessionStore):
+    """Redis-backed store for HTTP mode (multi-tenant, persistent).
+
+    Requires ``redis>=5.0.0`` (installed via the ``[mcp]`` extra).
+    Keys follow the format ``mcp:{user_id}:{type}:{id}`` where
+    ``user_id`` should be a hashed token (see :meth:`hash_token`).
+    """
+
+    QUERY_TTL = 3600  # 1 hour
+    CITATION_TTL = 7200  # 2 hours
+
+    def __init__(self, redis_client: Any) -> None:
+        self._redis = redis_client
+
+    def store_query(
+        self, user_id: str, query_id: str, data: dict
+    ) -> None:
+        key = f"mcp:{user_id}:query:{query_id}"
+        self._redis.set(key, json.dumps(data), ex=self.QUERY_TTL)
+
+    def get_query(
+        self, user_id: str, query_id: str
+    ) -> dict | None:
+        key = f"mcp:{user_id}:query:{query_id}"
+        raw = self._redis.get(key)
+        return json.loads(raw) if raw else None
+
+    def store_citation_analysis(
+        self, user_id: str, job_id: str, data: dict
+    ) -> None:
+        key = f"mcp:{user_id}:citation:{job_id}"
+        self._redis.set(
+            key, json.dumps(data), ex=self.CITATION_TTL
+        )
+
+    def get_citation_analysis(
+        self, user_id: str, job_id: str
+    ) -> dict | None:
+        key = f"mcp:{user_id}:citation:{job_id}"
+        raw = self._redis.get(key)
+        return json.loads(raw) if raw else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 mcp = [
     "eyecite>=2.6.0",
     "mcp>=1.0.0",
+    "redis>=5.0.0",
     "tiktoken>=0.12.0",
 ]
 dev = [

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,187 @@
+"""Tests for the SessionStore abstraction."""
+
+import json
+from unittest.mock import MagicMock
+
+from courtlistener.mcp.session import (
+    InMemorySessionStore,
+    RedisSessionStore,
+    SessionStore,
+)
+
+
+class TestMakeId:
+    """Tests for SessionStore.make_id()."""
+
+    def test_returns_8_char_hex_string(self):
+        store = InMemorySessionStore()
+        id_ = store.make_id()
+        assert len(id_) == 8
+        assert all(c in "0123456789abcdef" for c in id_)
+
+    def test_returns_unique_values(self):
+        store = InMemorySessionStore()
+        ids = {store.make_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestHashToken:
+    """Tests for SessionStore.hash_token()."""
+
+    def test_returns_16_char_hex(self):
+        h = SessionStore.hash_token("test-token-123")
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_deterministic(self):
+        a = SessionStore.hash_token("same-token")
+        b = SessionStore.hash_token("same-token")
+        assert a == b
+
+    def test_different_tokens_different_hashes(self):
+        a = SessionStore.hash_token("token-a")
+        b = SessionStore.hash_token("token-b")
+        assert a != b
+
+
+class TestInMemorySessionStore:
+    """Tests for InMemorySessionStore."""
+
+    def setup_method(self):
+        self.store = InMemorySessionStore()
+
+    # --- Query tests ---
+
+    def test_store_and_get_query(self):
+        data = {"response": "serialized", "fields": ["name"]}
+        self.store.store_query("user1", "abc12345", data)
+        assert self.store.get_query("user1", "abc12345") == data
+
+    def test_get_nonexistent_query_returns_none(self):
+        assert self.store.get_query("user1", "nope") is None
+
+    def test_query_user_isolation(self):
+        """User A cannot see user B's queries."""
+        self.store.store_query("userA", "q1", {"a": 1})
+        self.store.store_query("userB", "q1", {"b": 2})
+        assert self.store.get_query("userA", "q1") == {"a": 1}
+        assert self.store.get_query("userB", "q1") == {"b": 2}
+        assert self.store.get_query("userA", "q2") is None
+
+    def test_overwrite_query(self):
+        """Subsequent store_query calls overwrite previous data."""
+        self.store.store_query("user1", "q1", {"v": 1})
+        self.store.store_query("user1", "q1", {"v": 2})
+        assert self.store.get_query("user1", "q1") == {"v": 2}
+
+    # --- Citation analysis tests ---
+
+    def test_store_and_get_citation_analysis(self):
+        data = {"pending": [], "verified": {}}
+        self.store.store_citation_analysis("user1", "job1", data)
+        result = self.store.get_citation_analysis("user1", "job1")
+        assert result == data
+
+    def test_get_nonexistent_citation_returns_none(self):
+        result = self.store.get_citation_analysis("user1", "nope")
+        assert result is None
+
+    def test_citation_user_isolation(self):
+        """User A cannot see user B's citation analyses."""
+        self.store.store_citation_analysis("userA", "j1", {"a": 1})
+        self.store.store_citation_analysis("userB", "j1", {"b": 2})
+        assert self.store.get_citation_analysis("userA", "j1") == {
+            "a": 1
+        }
+        assert self.store.get_citation_analysis("userB", "j1") == {
+            "b": 2
+        }
+
+    def test_overwrite_citation_analysis(self):
+        """Subsequent store_citation_analysis calls overwrite previous data."""
+        self.store.store_citation_analysis(
+            "user1", "j1", {"pending": [1]}
+        )
+        self.store.store_citation_analysis(
+            "user1", "j1", {"pending": []}
+        )
+        assert self.store.get_citation_analysis("user1", "j1") == {
+            "pending": []
+        }
+
+
+class TestRedisSessionStore:
+    """Tests for RedisSessionStore using a mocked Redis client."""
+
+    def setup_method(self):
+        self.mock_redis = MagicMock()
+        self.store = RedisSessionStore(self.mock_redis)
+
+    # --- Query tests ---
+
+    def test_store_query_calls_redis_set_with_ttl(self):
+        data = {"response": "test"}
+        self.store.store_query("uid", "q1", data)
+        self.mock_redis.set.assert_called_once_with(
+            "mcp:uid:query:q1",
+            json.dumps(data),
+            ex=3600,
+        )
+
+    def test_get_query_returns_parsed_json(self):
+        data = {"response": "test"}
+        self.mock_redis.get.return_value = json.dumps(data)
+        result = self.store.get_query("uid", "q1")
+        self.mock_redis.get.assert_called_once_with(
+            "mcp:uid:query:q1"
+        )
+        assert result == data
+
+    def test_get_query_returns_none_when_missing(self):
+        self.mock_redis.get.return_value = None
+        assert self.store.get_query("uid", "q1") is None
+
+    # --- Citation analysis tests ---
+
+    def test_store_citation_calls_redis_set_with_ttl(self):
+        data = {"pending": []}
+        self.store.store_citation_analysis("uid", "j1", data)
+        self.mock_redis.set.assert_called_once_with(
+            "mcp:uid:citation:j1",
+            json.dumps(data),
+            ex=7200,
+        )
+
+    def test_get_citation_returns_parsed_json(self):
+        data = {"pending": []}
+        self.mock_redis.get.return_value = json.dumps(data)
+        result = self.store.get_citation_analysis("uid", "j1")
+        self.mock_redis.get.assert_called_once_with(
+            "mcp:uid:citation:j1"
+        )
+        assert result == data
+
+    def test_get_citation_returns_none_when_missing(self):
+        self.mock_redis.get.return_value = None
+        result = self.store.get_citation_analysis("uid", "nope")
+        assert result is None
+
+    # --- Key format tests ---
+
+    def test_query_key_format(self):
+        self.store.store_query("abc123", "def456", {})
+        key = self.mock_redis.set.call_args[0][0]
+        assert key == "mcp:abc123:query:def456"
+
+    def test_citation_key_format(self):
+        self.store.store_citation_analysis("abc123", "def456", {})
+        key = self.mock_redis.set.call_args[0][0]
+        assert key == "mcp:abc123:citation:def456"
+
+    # --- TTL constant tests ---
+
+    def test_query_ttl_is_one_hour(self):
+        assert RedisSessionStore.QUERY_TTL == 3600
+
+    def test_citation_ttl_is_two_hours(self):
+        assert RedisSessionStore.CITATION_TTL == 7200

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -90,21 +90,13 @@ class TestInMemorySessionStore:
         """User A cannot see user B's citation analyses."""
         self.store.store_citation_analysis("userA", "j1", {"a": 1})
         self.store.store_citation_analysis("userB", "j1", {"b": 2})
-        assert self.store.get_citation_analysis("userA", "j1") == {
-            "a": 1
-        }
-        assert self.store.get_citation_analysis("userB", "j1") == {
-            "b": 2
-        }
+        assert self.store.get_citation_analysis("userA", "j1") == {"a": 1}
+        assert self.store.get_citation_analysis("userB", "j1") == {"b": 2}
 
     def test_overwrite_citation_analysis(self):
         """Subsequent store_citation_analysis calls overwrite previous data."""
-        self.store.store_citation_analysis(
-            "user1", "j1", {"pending": [1]}
-        )
-        self.store.store_citation_analysis(
-            "user1", "j1", {"pending": []}
-        )
+        self.store.store_citation_analysis("user1", "j1", {"pending": [1]})
+        self.store.store_citation_analysis("user1", "j1", {"pending": []})
         assert self.store.get_citation_analysis("user1", "j1") == {
             "pending": []
         }
@@ -132,9 +124,7 @@ class TestRedisSessionStore:
         data = {"response": "test"}
         self.mock_redis.get.return_value = json.dumps(data)
         result = self.store.get_query("uid", "q1")
-        self.mock_redis.get.assert_called_once_with(
-            "mcp:uid:query:q1"
-        )
+        self.mock_redis.get.assert_called_once_with("mcp:uid:query:q1")
         assert result == data
 
     def test_get_query_returns_none_when_missing(self):
@@ -156,9 +146,7 @@ class TestRedisSessionStore:
         data = {"pending": []}
         self.mock_redis.get.return_value = json.dumps(data)
         result = self.store.get_citation_analysis("uid", "j1")
-        self.mock_redis.get.assert_called_once_with(
-            "mcp:uid:citation:j1"
-        )
+        self.mock_redis.get.assert_called_once_with("mcp:uid:citation:j1")
         assert result == data
 
     def test_get_citation_returns_none_when_missing(self):

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -295,6 +304,7 @@ dev = [
 mcp = [
     { name = "eyecite" },
     { name = "mcp" },
+    { name = "redis" },
     { name = "tiktoken" },
 ]
 
@@ -311,6 +321,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "redis", marker = "extra == 'mcp'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "tiktoken", marker = "extra == 'mcp'", specifier = ">=0.12.0" },
     { name = "tox-uv", marker = "extra == 'dev'", specifier = ">=1.29.0" },
@@ -1366,6 +1377,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<sub>🤖 Generated by my coding agent</sub>

## Summary

Implements the `SessionStore` abstraction layer described in #76, the foundational piece for the MCP Remote Server with Token Passthrough (#73).

- **`courtlistener/mcp/session.py`** — New module with three classes:
  - `SessionStore` (ABC): defines the storage interface, plus `make_id()` (8-char hex UUID via `uuid4`) and `hash_token()` (truncated SHA-256, for safe Redis key prefixing)
  - `InMemorySessionStore`: dict-backed store for stdio mode; user-scoped keys in the form `{user_id}:query:{query_id}` / `{user_id}:citation:{job_id}`
  - `RedisSessionStore`: Redis-backed store for HTTP/multi-tenant mode; keys prefixed with `mcp:`, TTLs of 1 hour for queries and 2 hours for citation analyses; accepts any Redis client via dependency injection
- **`pyproject.toml`** — Adds `redis>=5.0.0` to the `[mcp]` optional dependency group (alphabetical order between `mcp` and `tiktoken`)
- **`tests/test_session.py`** — 23 unit tests covering:
  - `make_id()` format and uniqueness
  - `hash_token()` length, determinism, and collision resistance
  - `InMemorySessionStore` CRUD, user isolation, and overwrite semantics
  - `RedisSessionStore` CRUD, exact key format, TTL values, and `None`-on-miss behaviour (using `unittest.mock.MagicMock` — no real Redis required)

## Test plan

- [x] All 23 new tests pass locally (`pytest tests/test_session.py -v`)
- [x] `ruff check` passes with no issues on new files
- [ ] CI passes on this PR

Closes #76