### PR TITLE
feat(mcp): add ToolAnnotations to all 14 MCP tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ The following changes are not yet released, but are code complete:
 Features:
 - Add session abstraction for MCP server and implement in-memory and redis-based sessions.
 - Add middleware to extract API token from Authorization header for MCP server.
+- Add tool annotation hints to MCP tools.
 
 Changes:
 -

--- a/courtlistener/mcp/tools/create_search_alert_tool.py
+++ b/courtlistener/mcp/tools/create_search_alert_tool.py
@@ -1,6 +1,6 @@
 import json
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
@@ -13,6 +13,12 @@ class CreateSearchAlertTool(MCPTool):
     """
 
     name: str = "create_search_alert"
+    annotations = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/delete_search_alert_tool.py
+++ b/courtlistener/mcp/tools/delete_search_alert_tool.py
@@ -1,4 +1,4 @@
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
@@ -11,6 +11,12 @@ class DeleteSearchAlertTool(MCPTool):
     """
 
     name: str = "delete_search_alert"
+    annotations = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/extract_citations_tool.py
+++ b/courtlistener/mcp/tools/extract_citations_tool.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from eyecite import get_citations, resolve_citations
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.mcp.tools.citation_utils import (
     citation_type_label,
@@ -24,6 +24,10 @@ class ExtractCitationsTool(MCPTool):
     """
 
     name: str = "extract_citations"
+    annotations = ToolAnnotations(
+        readOnlyHint=True,
+        openWorldHint=False,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/get_choices_tool.py
+++ b/courtlistener/mcp/tools/get_choices_tool.py
@@ -1,6 +1,6 @@
 import json
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.models import ENDPOINTS
@@ -13,6 +13,10 @@ class GetChoicesTool(MCPTool):
     """
 
     name: str = "get_choices"
+    annotations = ToolAnnotations(
+        readOnlyHint=True,
+        openWorldHint=False,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/get_endpoint_schema_tool.py
+++ b/courtlistener/mcp/tools/get_endpoint_schema_tool.py
@@ -1,6 +1,6 @@
 import json
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import prepare_filter
@@ -16,6 +16,10 @@ class GetEndpointSchemaTool(MCPTool):
     """
 
     name: str = "get_endpoint_schema"
+    annotations = ToolAnnotations(
+        readOnlyHint=True,
+        openWorldHint=False,
+    )
 
     def get_input_schema(self) -> dict:
         """Get the input schema for the get_endpoint_schema tool."""

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from mcp.types import CallToolResult, Tool
+from mcp.types import CallToolResult, Tool, ToolAnnotations
 
 from courtlistener import CourtListener
 from courtlistener.mcp.auth import request_api_token
@@ -9,6 +9,10 @@ from courtlistener.mcp.session import SessionStore
 
 class MCPTool:
     name: str | None = None
+    annotations: ToolAnnotations | None = ToolAnnotations(
+        readOnlyHint=True,
+        openWorldHint=True,
+    )
 
     def get_client(self) -> CourtListener:
         """Get a CourtListener client with the appropriate API token.
@@ -42,6 +46,7 @@ class MCPTool:
             name=self.name,
             description=self.get_description(),
             inputSchema=self.get_input_schema(),
+            annotations=self.annotations,
         )
 
     def get_description(self) -> str:

--- a/courtlistener/mcp/tools/subscribe_to_docket_alert_tool.py
+++ b/courtlistener/mcp/tools/subscribe_to_docket_alert_tool.py
@@ -1,6 +1,6 @@
 import json
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
@@ -14,6 +14,12 @@ class SubscribeToDocketAlertTool(MCPTool):
     """
 
     name: str = "subscribe_to_docket_alert"
+    annotations = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/unsubscribe_from_docket_alert_tool.py
+++ b/courtlistener/mcp/tools/unsubscribe_from_docket_alert_tool.py
@@ -1,4 +1,4 @@
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
@@ -15,6 +15,12 @@ class UnsubscribeFromDocketAlertTool(MCPTool):
     """
 
     name: str = "unsubscribe_from_docket_alert"
+    annotations = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,0 +1,90 @@
+"""Tests for MCP tool annotations (readOnlyHint, destructiveHint, etc.)."""
+
+from __future__ import annotations
+
+from courtlistener.mcp.tools import MCP_TOOLS
+
+READ_ONLY_TOOLS = {
+    "search",
+    "get_endpoint_schema",
+    "call_endpoint",
+    "get_endpoint_item",
+    "get_choices",
+    "get_counts",
+    "get_more_results",
+    "extract_citations",
+    "analyze_citations",
+    "resume_citation_analysis",
+}
+
+WRITE_TOOLS = {
+    "create_search_alert",
+    "delete_search_alert",
+    "subscribe_to_docket_alert",
+    "unsubscribe_from_docket_alert",
+}
+
+DESTRUCTIVE_TOOLS = {
+    "delete_search_alert",
+    "unsubscribe_from_docket_alert",
+}
+
+# Tools that operate on local data only (Pydantic schemas / eyecite);
+# no network calls are made, so openWorldHint=False.
+# Note: get_counts may make a lazy API call, so it is open-world.
+LOCAL_ONLY_TOOLS = {
+    "get_endpoint_schema",
+    "get_choices",
+    "extract_citations",
+}
+
+
+class TestToolAnnotations:
+    def test_all_tools_have_annotations(self):
+        """Every tool must expose a non-None annotations object."""
+        for name, tool in MCP_TOOLS.items():
+            t = tool.get_tool()
+            assert t.annotations is not None, (
+                f"{name} missing annotations"
+            )
+
+    def test_all_tools_accounted_for(self):
+        """READ_ONLY_TOOLS | WRITE_TOOLS must exactly match MCP_TOOLS."""
+        assert set(MCP_TOOLS.keys()) == READ_ONLY_TOOLS | WRITE_TOOLS
+
+    def test_read_only_tools(self):
+        """All read-only tools must have readOnlyHint=True."""
+        for name in READ_ONLY_TOOLS:
+            t = MCP_TOOLS[name].get_tool()
+            assert t.annotations.readOnlyHint is True, name
+
+    def test_write_tools(self):
+        """All write tools must have readOnlyHint=False."""
+        for name in WRITE_TOOLS:
+            t = MCP_TOOLS[name].get_tool()
+            assert t.annotations.readOnlyHint is False, name
+
+    def test_destructive_tools(self):
+        """Delete tools must have destructiveHint=True."""
+        for name in DESTRUCTIVE_TOOLS:
+            t = MCP_TOOLS[name].get_tool()
+            assert t.annotations.destructiveHint is True, name
+
+    def test_non_destructive_write_tools(self):
+        """Create tools must have destructiveHint=False."""
+        for name in WRITE_TOOLS - DESTRUCTIVE_TOOLS:
+            t = MCP_TOOLS[name].get_tool()
+            assert t.annotations.destructiveHint is False, name
+
+    def test_local_tools_closed_world(self):
+        """Purely-local tools must have openWorldHint=False."""
+        for name in LOCAL_ONLY_TOOLS:
+            t = MCP_TOOLS[name].get_tool()
+            assert t.annotations.openWorldHint is False, name
+
+    def test_api_tools_open_world(self):
+        """All non-local tools must have openWorldHint=True."""
+        api_tools = set(MCP_TOOLS.keys()) - LOCAL_ONLY_TOOLS
+        for name in api_tools:
+            t = MCP_TOOLS[name].get_tool()
+            assert t.annotations.openWorldHint is True, name

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -44,9 +44,7 @@ class TestToolAnnotations:
         """Every tool must expose a non-None annotations object."""
         for name, tool in MCP_TOOLS.items():
             t = tool.get_tool()
-            assert t.annotations is not None, (
-                f"{name} missing annotations"
-            )
+            assert t.annotations is not None, f"{name} missing annotations"
 
     def test_all_tools_accounted_for(self):
         """READ_ONLY_TOOLS | WRITE_TOOLS must exactly match MCP_TOOLS."""


### PR DESCRIPTION
<sub>🤖 Generated by my coding agent</sub>

## Summary

Implements the `ToolAnnotations` changes described in #69, enabling LLM clients to identify which tools are safe to call in parallel (read-only) and which have side effects.

### Approach

A default `annotations` class variable is added to `MCPTool` with `readOnlyHint=True, openWorldHint=True`. This covers 10 of the 14 tools automatically. The remaining tools override only what differs:

| Category | Tools | Annotations |
|----------|-------|-------------|
| **Default (read-only, API)** | `search`, `call_endpoint`, `get_endpoint_item`, `get_counts`, `get_more_results`, `analyze_citations`, `resume_citation_analysis` | `readOnlyHint=True, openWorldHint=True` |
| **Local-only read** | `get_endpoint_schema`, `get_choices`, `extract_citations` | `readOnlyHint=True, openWorldHint=False` |
| **Create-resource write** | `create_search_alert`, `subscribe_to_docket_alert` | `readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True` |
| **Delete-resource write** | `delete_search_alert`, `unsubscribe_from_docket_alert` | `readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=True` |

`get_counts` keeps `openWorldHint=True` (confirmed in issue — it may make a lazy API call via `ResourceIterator`).

### Files changed

- **`courtlistener/mcp/tools/mcp_tool.py`** — adds `ToolAnnotations` import, default `annotations` class variable, passes `annotations=self.annotations` in `get_tool()`
- **`get_endpoint_schema_tool.py`, `get_choices_tool.py`, `extract_citations_tool.py`** — override `openWorldHint=False`
- **`create_search_alert_tool.py`, `subscribe_to_docket_alert_tool.py`** — override as non-destructive write tools
- **`delete_search_alert_tool.py`, `unsubscribe_from_docket_alert_tool.py`** — override as destructive write tools
- **`tests/test_tool_annotations.py`** — 8 new tests verifying annotations for all 14 tools

## Test plan

- [x] `test_all_tools_have_annotations` — every tool exposes non-None annotations
- [x] `test_all_tools_accounted_for` — set of tool names exactly matches expectations
- [x] `test_read_only_tools` — all 10 read-only tools have `readOnlyHint=True`
- [x] `test_write_tools` — all 4 write tools have `readOnlyHint=False`
- [x] `test_destructive_tools` — delete tools have `destructiveHint=True`
- [x] `test_non_destructive_write_tools` — create tools have `destructiveHint=False`
- [x] `test_local_tools_closed_world` — local tools have `openWorldHint=False`
- [x] `test_api_tools_open_world` — all other tools have `openWorldHint=True`

Closes #69