### PR TITLE
feat(mcp): add human-readable titles to all 14 MCP tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Features:
 - Add session abstraction for MCP server and implement in-memory and redis-based sessions.
 - Add middleware to extract API token from Authorization header for MCP server.
 - Add tool annotation hints to MCP tools.
+- Add human-readable titles to all MCP tools via ToolAnnotations.
 
 Changes:
 -

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from eyecite import get_citations, resolve_citations
 from eyecite.models import FullCaseCitation
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.citation_utils import (
@@ -34,6 +34,11 @@ class AnalyzeCitationsTool(MCPTool):
     """
 
     name: str = "analyze_citations"
+    annotations = ToolAnnotations(
+        title="Analyzing Citations",
+        readOnlyHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/call_endpoint_tool.py
+++ b/courtlistener/mcp/tools/call_endpoint_tool.py
@@ -1,6 +1,6 @@
 import json
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import (
@@ -23,6 +23,11 @@ class CallEndpointTool(MCPTool):
     """
 
     name: str = "call_endpoint"
+    annotations = ToolAnnotations(
+        title="Calling API Endpoint",
+        readOnlyHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         """Get the input schema for the call_endpoint tool."""

--- a/courtlistener/mcp/tools/create_search_alert_tool.py
+++ b/courtlistener/mcp/tools/create_search_alert_tool.py
@@ -14,6 +14,7 @@ class CreateSearchAlertTool(MCPTool):
 
     name: str = "create_search_alert"
     annotations = ToolAnnotations(
+        title="Creating Search Alert",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,

--- a/courtlistener/mcp/tools/delete_search_alert_tool.py
+++ b/courtlistener/mcp/tools/delete_search_alert_tool.py
@@ -12,6 +12,7 @@ class DeleteSearchAlertTool(MCPTool):
 
     name: str = "delete_search_alert"
     annotations = ToolAnnotations(
+        title="Deleting Search Alert",
         readOnlyHint=False,
         destructiveHint=True,
         idempotentHint=True,

--- a/courtlistener/mcp/tools/extract_citations_tool.py
+++ b/courtlistener/mcp/tools/extract_citations_tool.py
@@ -25,6 +25,7 @@ class ExtractCitationsTool(MCPTool):
 
     name: str = "extract_citations"
     annotations = ToolAnnotations(
+        title="Extracting Citations",
         readOnlyHint=True,
         openWorldHint=False,
     )

--- a/courtlistener/mcp/tools/get_choices_tool.py
+++ b/courtlistener/mcp/tools/get_choices_tool.py
@@ -14,6 +14,7 @@ class GetChoicesTool(MCPTool):
 
     name: str = "get_choices"
     annotations = ToolAnnotations(
+        title="Getting Field Choices",
         readOnlyHint=True,
         openWorldHint=False,
     )

--- a/courtlistener/mcp/tools/get_counts_tool.py
+++ b/courtlistener/mcp/tools/get_counts_tool.py
@@ -1,4 +1,4 @@
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
@@ -13,6 +13,11 @@ class GetCountsTool(MCPTool):
     """
 
     name: str = "get_counts"
+    annotations = ToolAnnotations(
+        title="Getting Result Count",
+        readOnlyHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/get_endpoint_item_tool.py
+++ b/courtlistener/mcp/tools/get_endpoint_item_tool.py
@@ -1,6 +1,6 @@
 import json
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
@@ -11,6 +11,11 @@ class GetEndpointItemTool(MCPTool):
     """Get an item by ID from a CourtListener API endpoint."""
 
     name: str = "get_endpoint_item"
+    annotations = ToolAnnotations(
+        title="Getting Item by ID",
+        readOnlyHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         """Get the input schema for the get_endpoint_item tool."""

--- a/courtlistener/mcp/tools/get_endpoint_schema_tool.py
+++ b/courtlistener/mcp/tools/get_endpoint_schema_tool.py
@@ -17,6 +17,7 @@ class GetEndpointSchemaTool(MCPTool):
 
     name: str = "get_endpoint_schema"
     annotations = ToolAnnotations(
+        title="Getting Endpoint Schema",
         readOnlyHint=True,
         openWorldHint=False,
     )

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -1,6 +1,6 @@
 import json
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import (
@@ -22,6 +22,11 @@ class GetMoreResultsTool(MCPTool):
     """
 
     name: str = "get_more_results"
+    annotations = ToolAnnotations(
+        title="Getting More Results",
+        readOnlyHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -9,10 +9,7 @@ from courtlistener.mcp.session import SessionStore
 
 class MCPTool:
     name: str | None = None
-    annotations: ToolAnnotations | None = ToolAnnotations(
-        readOnlyHint=True,
-        openWorldHint=True,
-    )
+    annotations: ToolAnnotations | None = None
 
     def get_client(self) -> CourtListener:
         """Get a CourtListener client with the appropriate API token.
@@ -42,6 +39,8 @@ class MCPTool:
     def get_tool(self) -> Tool:
         if self.name is None:
             raise ValueError("name must be set")
+        if self.annotations is None:
+            raise ValueError("annotations must be set")
         return Tool(
             name=self.name,
             description=self.get_description(),

--- a/courtlistener/mcp/tools/resume_citation_analysis_tool.py
+++ b/courtlistener/mcp/tools/resume_citation_analysis_tool.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.mcp.tools.citation_utils import (
     MAX_CITATIONS_PER_REQUEST,
@@ -22,6 +22,11 @@ class ResumeCitationAnalysisTool(MCPTool):
     """
 
     name: str = "resume_citation_analysis"
+    annotations = ToolAnnotations(
+        title="Resuming Citation Analysis",
+        readOnlyHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         return {

--- a/courtlistener/mcp/tools/search_tool.py
+++ b/courtlistener/mcp/tools/search_tool.py
@@ -1,6 +1,6 @@
 import json
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import (
@@ -27,6 +27,11 @@ class SearchTool(MCPTool):
     """
 
     name: str = "search"
+    annotations = ToolAnnotations(
+        title="Searching CourtListener",
+        readOnlyHint=True,
+        openWorldHint=True,
+    )
 
     def get_input_schema(self) -> dict:
         """Get the input schema for the search tool."""

--- a/courtlistener/mcp/tools/subscribe_to_docket_alert_tool.py
+++ b/courtlistener/mcp/tools/subscribe_to_docket_alert_tool.py
@@ -15,6 +15,7 @@ class SubscribeToDocketAlertTool(MCPTool):
 
     name: str = "subscribe_to_docket_alert"
     annotations = ToolAnnotations(
+        title="Subscribing to Docket Alert",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,

--- a/courtlistener/mcp/tools/unsubscribe_from_docket_alert_tool.py
+++ b/courtlistener/mcp/tools/unsubscribe_from_docket_alert_tool.py
@@ -16,6 +16,7 @@ class UnsubscribeFromDocketAlertTool(MCPTool):
 
     name: str = "unsubscribe_from_docket_alert"
     annotations = ToolAnnotations(
+        title="Unsubscribing from Docket Alert",
         readOnlyHint=False,
         destructiveHint=True,
         idempotentHint=True,

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -38,6 +38,23 @@ LOCAL_ONLY_TOOLS = {
     "extract_citations",
 }
 
+EXPECTED_TITLES = {
+    "search": "Searching CourtListener",
+    "get_endpoint_schema": "Getting Endpoint Schema",
+    "call_endpoint": "Calling API Endpoint",
+    "get_endpoint_item": "Getting Item by ID",
+    "get_choices": "Getting Field Choices",
+    "get_counts": "Getting Result Count",
+    "get_more_results": "Getting More Results",
+    "extract_citations": "Extracting Citations",
+    "analyze_citations": "Analyzing Citations",
+    "resume_citation_analysis": "Resuming Citation Analysis",
+    "create_search_alert": "Creating Search Alert",
+    "delete_search_alert": "Deleting Search Alert",
+    "subscribe_to_docket_alert": "Subscribing to Docket Alert",
+    "unsubscribe_from_docket_alert": "Unsubscribing from Docket Alert",
+}
+
 
 class TestToolAnnotations:
     def test_all_tools_have_annotations(self):
@@ -86,3 +103,32 @@ class TestToolAnnotations:
         for name in api_tools:
             t = MCP_TOOLS[name].get_tool()
             assert t.annotations.openWorldHint is True, name
+
+
+class TestToolTitles:
+    def test_all_tools_have_titles(self):
+        """Every registered tool must have a non-empty title."""
+        for name, tool in MCP_TOOLS.items():
+            t = tool.get_tool()
+            assert t.annotations is not None, (
+                f"{name} missing annotations"
+            )
+            assert t.annotations.title, f"{name} missing title"
+
+    def test_titles_are_human_readable(self):
+        """Titles must not be snake_case machine names."""
+        for name, tool in MCP_TOOLS.items():
+            t = tool.get_tool()
+            assert "_" not in t.annotations.title, (
+                f"{name} title looks like a machine name: "
+                f"{t.annotations.title!r}"
+            )
+
+    def test_title_values(self):
+        """Verify exact title string for every tool."""
+        for name, expected_title in EXPECTED_TITLES.items():
+            t = MCP_TOOLS[name].get_tool()
+            assert t.annotations.title == expected_title, (
+                f"{name}: expected {expected_title!r}, "
+                f"got {t.annotations.title!r}"
+            )

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -124,6 +124,9 @@ class TestToolTitles:
 
     def test_title_values(self):
         """Verify exact title string for every tool."""
+        assert set(EXPECTED_TITLES.keys()) == set(MCP_TOOLS.keys()), (
+            "EXPECTED_TITLES is out of sync with MCP_TOOLS"
+        )
         for name, expected_title in EXPECTED_TITLES.items():
             t = MCP_TOOLS[name].get_tool()
             assert t.annotations.title == expected_title, (

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -110,9 +110,7 @@ class TestToolTitles:
         """Every registered tool must have a non-empty title."""
         for name, tool in MCP_TOOLS.items():
             t = tool.get_tool()
-            assert t.annotations is not None, (
-                f"{name} missing annotations"
-            )
+            assert t.annotations is not None, f"{name} missing annotations"
             assert t.annotations.title, f"{name} missing title"
 
     def test_titles_are_human_readable(self):


### PR DESCRIPTION
<sub>🤖 Generated by my coding agent</sub>

## Summary

Implements the `title` attribute for MCP tools described in #71, so chat UIs display friendly labels (e.g. "Searching CourtListener") instead of raw snake_case names during tool calls.

### Design (per issue discussion)

The original plan proposed a `title` class attribute alongside the existing `annotations`. After reviewing the overlap with #69/#83, the owner's direction was:

> "set `annotations` to `None` on the base class and find a good place to raise if it's not set on subclasses. Then update all tools to spell out their annotations specifically."

So this PR:
1. **Removes the base-class default** — `annotations` is now `None` on `MCPTool`; `get_tool()` raises `ValueError` if a subclass forgets to set it (analogous to the existing `name` check)
2. **Every tool has its own explicit `ToolAnnotations`** — titles use the gerund form per the owner's preference ("Searching CourtListener" not "Search CourtListener")
3. **7 tools that previously relied on the default** now spell out their complete annotations (search, call_endpoint, get_endpoint_item, get_counts, get_more_results, analyze_citations, resume_citation_analysis)

### Titles

| Tool | Title |
|------|-------|
| `search` | Searching CourtListener |
| `get_endpoint_schema` | Getting Endpoint Schema |
| `call_endpoint` | Calling API Endpoint |
| `get_endpoint_item` | Getting Item by ID |
| `get_choices` | Getting Field Choices |
| `get_counts` | Getting Result Count |
| `get_more_results` | Getting More Results |
| `extract_citations` | Extracting Citations |
| `analyze_citations` | Analyzing Citations |
| `resume_citation_analysis` | Resuming Citation Analysis |
| `create_search_alert` | Creating Search Alert |
| `delete_search_alert` | Deleting Search Alert |
| `subscribe_to_docket_alert` | Subscribing to Docket Alert |
| `unsubscribe_from_docket_alert` | Unsubscribing from Docket Alert |

### Tests

Extends `tests/test_tool_annotations.py` with a new `TestToolTitles` class (3 tests):
- `test_all_tools_have_titles` — every tool has a non-empty title
- `test_titles_are_human_readable` — no underscores (not machine names)
- `test_title_values` — exact string match for all 14 tools

Closes #71