### PR TITLE
feat(client): make COURTLISTENER_API_BASE_URL configurable from env

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Features:
 Changes:
 - Update pre-commit hooks to latest versions.
 - Refactor MCP server to use FastMCP.
+- Make COURTLISTENER_API_BASE_URL configurable via environment variable.
 
 Fixes:
 -

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -12,6 +12,7 @@ The CourtListener MCP server is a FastMCP server that provides a MCP interface t
 | `TARGET_ENV` | Whether to run the server in `prod` or `dev` mode. |
 | `REDIS_URL` | The URL of the Redis server. |
 | `MCP_WORKERS` | The number of gunicorn workers to run the server with in `prod` mode. |
+| `COURTLISTENER_API_BASE_URL` | The base URL of the CourtListener API. Defaults to the real CourtListener API base URL, but can be overridden to use a local development API. |
 --------------------------------
 
 ### Development
@@ -23,6 +24,12 @@ docker compose up --build
 ```
 
 The server will be available at `http://localhost:8080`.
+
+If you want to point to a local CourtListener instance, you can set the `COURTLISTENER_API_BASE_URL` environment variable to the base URL of the local API. Because the MCP server is running in a Docker container, you can use the `host.docker.internal` hostname to point to your host machine's `localhost`. For example:
+
+```bash
+COURTLISTENER_API_BASE_URL=http://host.docker.internal:8000/api/rest/v4
+```
 
 Here is an example script to make a test tool call to the server:
 

--- a/courtlistener/client.py
+++ b/courtlistener/client.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from courtlistener.alerts import DocketAlerts, SearchAlerts
     from courtlistener.citation_lookup import CitationLookup
 
-DEFAULT_BASE_URL = "https://www.courtlistener.com/api/rest/v4"
+DEFAULT_API_BASE_URL = "https://www.courtlistener.com/api/rest/v4"
 
 
 class CourtListener:
@@ -22,7 +22,7 @@ class CourtListener:
     def __init__(
         self,
         api_token: str | None = None,
-        base_url: str = DEFAULT_BASE_URL,
+        base_url: str | None = None,
         timeout: float = 300.0,
     ) -> None:
         """Initialize the CourtListener client.
@@ -38,6 +38,12 @@ class CourtListener:
             raise ValueError(
                 "API token is required. Provide it directly or set COURTLISTENER_API_TOKEN "
                 "environment variable."
+            )
+
+        if base_url is None:
+            base_url = (
+                os.environ.get("COURTLISTENER_API_BASE_URL")
+                or DEFAULT_API_BASE_URL
             )
 
         self.base_url = base_url.rstrip("/")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       TARGET_ENV: dev
       REDIS_URL: redis://redis:6379
+      COURTLISTENER_API_BASE_URL: ${COURTLISTENER_API_BASE_URL:-}
     healthcheck:
       test: [
         "CMD", "python", "-c",


### PR DESCRIPTION
Fixes #99

This PR adds COURTLISTENER_API_BASE_URL support to the API client. Set this to `http://host.docker.internal:8000/api/rest/v4` if you want to point to a local CourtListener instance in development.