### PR TITLE
Add GitHub action to deploy MCP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,177 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  AWS_REGION: us-west-2
+  EKS_CLUSTER_NAME: courtlistener
+  EKS_NAMESPACE: wiki
+
+jobs:
+  get-pr-labels:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.find_pr.outputs.labels }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Find merged PR by merge_commit_sha
+        id: find_pr
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const commitSha = context.sha;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "closed",
+              sort: "updated",
+              direction: "desc",
+              per_page: 1
+            });
+
+            const pr = prs.find(p => p.merge_commit_sha === commitSha);
+            if (!pr) {
+              core.setOutput("labels", "");
+              core.warning("No merged PR found for this commit.");
+              return;
+            }
+
+            const labels = pr.labels.map(l => l.name);
+            core.setOutput("labels", labels.join(","));
+            console.log(`PR #${pr.number} labels: ${labels.join(", ")}`);
+
+  build:
+    needs: get-pr-labels
+    runs-on: ubuntu-latest
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-deploy') }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        run: |
+          make push-image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+
+  setup-deploy:
+    needs: [get-pr-labels, build]
+    runs-on: ubuntu-latest
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set shortcode
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create Kubeconfig with AWS CLI
+        run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
+
+      - name: Update Environment Variables
+        env:
+          WIKI_ENV: wiki-env
+        run: kubectl annotate es $WIKI_ENV force-sync=$(date +%s) --overwrite -n ${{ env.EKS_NAMESPACE }} && kubectl wait es -n ${{ env.EKS_NAMESPACE }} --for=jsonpath="{.status.conditions[?(@.reason=='SecretSynced')].status}"=True --timeout=30s $WIKI_ENV
+
+      - name: Launch Temporary Pod
+        run: |
+          kubectl run temp-pod-${{ steps.vars.outputs.sha_short }} -n ${{ env.EKS_NAMESPACE }} --image=freelawproject/wiki:${{ steps.vars.outputs.sha_short }}-prod --restart Never --pod-running-timeout=120s --overrides='
+          {
+              "spec": {
+              "containers": [{
+                  "name": "temp-pod",
+                  "image": "freelawproject/wiki:${{ steps.vars.outputs.sha_short }}-prod",
+                  "command": ["/bin/sh", "-c", "trap : TERM INT; sleep 259200 & wait"],
+                  "envFrom": [{
+                  "secretRef": {
+                      "name": "wiki-env"
+                  }
+                  }]
+              }]
+              }
+          }'
+      - name: Wait for Temporary Pod to Start
+        run: kubectl wait pods -n ${{ env.EKS_NAMESPACE }} --for condition=Ready --timeout=90s temp-pod-${{ steps.vars.outputs.sha_short }}
+      - name: Collect Static Assets
+        run: |
+          kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- ./manage.py collectstatic --noinput
+      - name: Handle Collectstatic Error
+        if: failure()
+        run: |
+          echo "collectstatic failed--aborting build"
+          exit 1
+
+      - name: Check Migrations
+        run: |
+          kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- ./manage.py migrate --check
+      - name: Handle Check Migrations Error
+        if: failure()
+        run: |
+          echo "Found unapplied migrations. Open shell into pod temp-pod-${{ steps.vars.outputs.sha_short }}"
+          echo "Manually run migrations. That pod will delete itself after an hour."
+          exit 1
+      - name: Delete Temporary Pod
+        run: kubectl delete pod -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }}
+
+  deploy-web:
+    needs: [get-pr-labels, setup-deploy]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Create Kubeconfig with AWS CLI
+        run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
+
+      - name: Rollout wiki-web
+        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/wiki-web web=freelawproject/wiki:${{ needs.setup-deploy.outputs.sha_short }}-prod
+      - name: Watch wiki-web rollout status
+        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/wiki-web
+
+  deploy-daemon:
+    needs: [get-pr-labels, setup-deploy]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-daemon-deploy') }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Create Kubeconfig with AWS CLI
+        run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
+
+      - name: Rollout wiki-daemon
+        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/wiki-daemon wiki-daemon=freelawproject/wiki:${{ needs.setup-deploy.outputs.sha_short }}-prod
+      - name: Watch wiki-daemon rollout status
+        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/wiki-daemon
+
+  complete-deploy:
+    needs:
+      [
+        deploy-web,
+        deploy-daemon,
+      ]
+    runs-on: ubuntu-latest
+    concurrency: production
+    if: always()
+    steps:
+      - name: Deployment Complete
+        run: echo "All deployments have finished."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,12 +57,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         run: |
-          VERSION=$(git rev-parse --short HEAD)
-          docker build \
-            --build-arg TARGET_ENV=prod \
-            --tag freelawproject/courtlistener-mcp:${VERSION}-prod \
-            .
-          docker push freelawproject/courtlistener-mcp:${VERSION}-prod
+          make push-image -e VERSION=$(git rev-parse --short HEAD)
 
   setup-deploy:
     needs: [get-pr-labels, build]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 env:
   AWS_REGION: us-west-2
   EKS_CLUSTER_NAME: courtlistener
-  EKS_NAMESPACE: mcp
+  EKS_NAMESPACE: courtlistener-mcp
 
 jobs:
   get-pr-labels:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 env:
   AWS_REGION: us-west-2
   EKS_CLUSTER_NAME: courtlistener
-  EKS_NAMESPACE: wiki
+  EKS_NAMESPACE: mcp
 
 jobs:
   get-pr-labels:
@@ -57,7 +57,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         run: |
-          make push-image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+          VERSION=$(git rev-parse --short HEAD)
+          docker build \
+            --build-arg TARGET_ENV=prod \
+            --tag freelawproject/courtlistener-mcp:${VERSION}-prod \
+            .
+          docker push freelawproject/courtlistener-mcp:${VERSION}-prod
 
   setup-deploy:
     needs: [get-pr-labels, build]
@@ -82,48 +87,8 @@ jobs:
 
       - name: Update Environment Variables
         env:
-          WIKI_ENV: wiki-env
-        run: kubectl annotate es $WIKI_ENV force-sync=$(date +%s) --overwrite -n ${{ env.EKS_NAMESPACE }} && kubectl wait es -n ${{ env.EKS_NAMESPACE }} --for=jsonpath="{.status.conditions[?(@.reason=='SecretSynced')].status}"=True --timeout=30s $WIKI_ENV
-
-      - name: Launch Temporary Pod
-        run: |
-          kubectl run temp-pod-${{ steps.vars.outputs.sha_short }} -n ${{ env.EKS_NAMESPACE }} --image=freelawproject/wiki:${{ steps.vars.outputs.sha_short }}-prod --restart Never --pod-running-timeout=120s --overrides='
-          {
-              "spec": {
-              "containers": [{
-                  "name": "temp-pod",
-                  "image": "freelawproject/wiki:${{ steps.vars.outputs.sha_short }}-prod",
-                  "command": ["/bin/sh", "-c", "trap : TERM INT; sleep 259200 & wait"],
-                  "envFrom": [{
-                  "secretRef": {
-                      "name": "wiki-env"
-                  }
-                  }]
-              }]
-              }
-          }'
-      - name: Wait for Temporary Pod to Start
-        run: kubectl wait pods -n ${{ env.EKS_NAMESPACE }} --for condition=Ready --timeout=90s temp-pod-${{ steps.vars.outputs.sha_short }}
-      - name: Collect Static Assets
-        run: |
-          kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- ./manage.py collectstatic --noinput
-      - name: Handle Collectstatic Error
-        if: failure()
-        run: |
-          echo "collectstatic failed--aborting build"
-          exit 1
-
-      - name: Check Migrations
-        run: |
-          kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- ./manage.py migrate --check
-      - name: Handle Check Migrations Error
-        if: failure()
-        run: |
-          echo "Found unapplied migrations. Open shell into pod temp-pod-${{ steps.vars.outputs.sha_short }}"
-          echo "Manually run migrations. That pod will delete itself after an hour."
-          exit 1
-      - name: Delete Temporary Pod
-        run: kubectl delete pod -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }}
+          MCP_ENV: mcp-env
+        run: kubectl annotate es $MCP_ENV force-sync=$(date +%s) --overwrite -n ${{ env.EKS_NAMESPACE }} && kubectl wait es -n ${{ env.EKS_NAMESPACE }} --for=jsonpath="{.status.conditions[?(@.reason=='SecretSynced')].status}"=True --timeout=30s $MCP_ENV
 
   deploy-web:
     needs: [get-pr-labels, setup-deploy]
@@ -139,35 +104,15 @@ jobs:
       - name: Create Kubeconfig with AWS CLI
         run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
 
-      - name: Rollout wiki-web
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/wiki-web web=freelawproject/wiki:${{ needs.setup-deploy.outputs.sha_short }}-prod
-      - name: Watch wiki-web rollout status
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/wiki-web
-
-  deploy-daemon:
-    needs: [get-pr-labels, setup-deploy]
-    runs-on: ubuntu-latest
-    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-daemon-deploy') }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Create Kubeconfig with AWS CLI
-        run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
-
-      - name: Rollout wiki-daemon
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/wiki-daemon wiki-daemon=freelawproject/wiki:${{ needs.setup-deploy.outputs.sha_short }}-prod
-      - name: Watch wiki-daemon rollout status
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/wiki-daemon
+      - name: Rollout mcp-web
+        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/mcp-web web=freelawproject/courtlistener-mcp:${{ needs.setup-deploy.outputs.sha_short }}-prod
+      - name: Watch mcp-web rollout status
+        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/mcp-web
 
   complete-deploy:
     needs:
       [
         deploy-web,
-        deploy-daemon,
       ]
     runs-on: ubuntu-latest
     concurrency: production

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,13 @@ Features:
 - Add human-readable titles to all MCP tools via ToolAnnotations.
 - Add factory for HTTP MCP server with Redis session state store.
 - Add Docker Compose configuration for development.
+- Report the image version (Git SHA) on the MCP `/health` endpoint.
 
 Changes:
 - Update pre-commit hooks to latest versions.
 - Refactor MCP server to use FastMCP.
 - Make COURTLISTENER_API_BASE_URL configurable via environment variable.
+- Add CI workflow and Makefile for building and deploying the MCP server.
 
 Fixes:
 -

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,11 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ARG TARGET_ENV=dev
 ENV TARGET_ENV=${TARGET_ENV}
 
+# Bake the short commit SHA into the image so running containers can report
+# which build they came from. Passed in by CI / the Makefile.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
 RUN uv sync --extra mcp --frozen;
 
 RUN chmod +x /app/docker-entrypoint.sh

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -84,36 +84,9 @@ builds), you can bridge to the remote server with
 ### Programmatic access
 
 If you want to call the server from code — for testing, scripting, or building
-your own agent — use any MCP client library. Here's an example with the
-`fastmcp` Python client:
-
-```python
-import asyncio
-import os
-
-from fastmcp import Client
-from fastmcp.client.transports import StreamableHttpTransport
-
-
-async def main():
-    async with Client(
-        transport=StreamableHttpTransport(
-            "https://mcp.courtlistener.com/",
-            headers={
-                "Authorization": f"Token {os.environ['COURTLISTENER_API_TOKEN']}"
-            },
-        ),
-    ) as client:
-        result = await client.call_tool(
-            "get_endpoint_item",
-            {"endpoint_id": "courts", "item_id": "scotus"},
-        )
-        print(result)
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
-```
+your own agent — use any MCP client library. See
+[Calling the server from code](#calling-the-server-from-code) in the
+Development section for an example.
 
 ---
 
@@ -123,23 +96,20 @@ You can also run the server on your own machine. Two transports are supported.
 
 ### stdio (recommended for local desktop clients)
 
-Install the package with the `mcp` extra:
-
-```bash
-pip install 'courtlistener-api-client[mcp]'
-```
-
-That installs a `courtlistener-mcp` console script (defined in
-`pyproject.toml` and backed by `courtlistener.mcp.server:main`) that runs the
-server over stdio — the transport most desktop MCP clients expect for local
-servers.
+The easiest way to run the stdio server is with
+[`uvx`](https://docs.astral.sh/uv/guides/tools/), which fetches the
+`courtlistener-api-client` package from PyPI and runs the
+`courtlistener-mcp` console script (backed by `courtlistener.mcp.server:main`)
+in an ephemeral environment — no manual install required. If you don't have
+`uv` yet, follow the
+[uv install instructions](https://docs.astral.sh/uv/getting-started/installation/).
 
 Authentication in stdio mode uses the `COURTLISTENER_API_TOKEN` environment
 variable (there is no request to attach headers to):
 
 ```bash
 export COURTLISTENER_API_TOKEN="your-token-here"
-courtlistener-mcp
+uvx --from 'courtlistener-api-client[mcp]' courtlistener-mcp
 ```
 
 A Claude Desktop–style config entry looks like this:
@@ -148,7 +118,12 @@ A Claude Desktop–style config entry looks like this:
 {
   "mcpServers": {
     "courtlistener": {
-      "command": "courtlistener-mcp",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "courtlistener-api-client[mcp]",
+        "courtlistener-mcp"
+      ],
       "env": {
         "COURTLISTENER_API_TOKEN": "your-token-here"
       }
@@ -156,6 +131,10 @@ A Claude Desktop–style config entry looks like this:
   }
 }
 ```
+
+If you'd rather install the package into an environment yourself,
+`pip install 'courtlistener-api-client[mcp]'` exposes the same
+`courtlistener-mcp` command on your `PATH`.
 
 stdio mode does not require Redis.
 
@@ -213,12 +192,55 @@ The MCP code lives under `courtlistener/mcp/`:
 See the `COURTLISTENER_API_BASE_URL` instructions in the HTTP section above.
 The same variable works in stdio mode if you prefer to iterate without Docker.
 
+### Calling the server from code
+
+Any MCP client library works against the running server — useful for smoke
+tests, one-off scripts, or building your own agent. Here's an example against
+the hosted server using the `fastmcp` Python client:
+
+```python
+import asyncio
+import os
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+
+async def main():
+    async with Client(
+        transport=StreamableHttpTransport(
+            "https://mcp.courtlistener.com/",
+            headers={
+                "Authorization": f"Token {os.environ['COURTLISTENER_API_TOKEN']}"
+            },
+        ),
+    ) as client:
+        result = await client.call_tool(
+            "get_endpoint_item",
+            {"endpoint_id": "courts", "item_id": "scotus"},
+        )
+        print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Swap the URL for `http://localhost:8080/` to hit a locally running HTTP
+instance instead.
+
 ### Tests and linting
 
 Tests, linting, and type-checking run via `tox`:
 
 ```bash
 tox
+```
+
+Run the pre-commit hooks (formatting, lint, etc.) across the whole repo with:
+
+```bash
+pre-commit run --all-files
 ```
 
 CI runs the same targets on pull requests.

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -1,61 +1,112 @@
 # CourtListener MCP Server
 
-The CourtListener MCP server is a FastMCP server that provides a MCP interface to the CourtListener API.
+A [FastMCP](https://github.com/jlowin/fastmcp) server that exposes the
+[CourtListener API](https://www.courtlistener.com/help/api/rest/v4) to
+[Model Context Protocol](https://modelcontextprotocol.io) clients. Use it to
+let an MCP-capable LLM (Claude Desktop, Cursor, Goose, etc.) search opinions,
+retrieve dockets, analyze citations, manage alerts, and more.
 
-## Remote MCP Server
+This document covers three things, in order:
 
-### Environment
+1. [Connecting to the hosted server](#connecting-to-the-hosted-server) at
+   `mcp.courtlistener.com` (the option most users want)
+2. [Running the server locally](#running-the-server-locally) over stdio or HTTP
+3. [Development and deployment](#development) of the server itself
 
---------------------------------
-| Variable | Description |
+---
+
+## Connecting to the hosted server
+
+Free Law Project hosts a public instance of this server at:
+
+```
+https://mcp.courtlistener.com/
+```
+
+It speaks the MCP [Streamable HTTP](https://modelcontextprotocol.io/specification/basic/transports#streamable-http)
+transport. Any MCP client that supports Streamable HTTP with custom headers can
+connect to it.
+
+### Authentication
+
+You need a CourtListener API token. Create one from your
+[profile settings](https://www.courtlistener.com/profile/api/) (free account
+required).
+
+All requests must include the token in an `Authorization` header:
+
+```
+Authorization: Token <your-token-here>
+```
+
+Requests without a valid token will be rejected.
+
+> **OAuth is coming soon.** Token-in-header auth is the current mechanism, but
+> we plan to support OAuth so clients can connect without users having to
+> copy-paste API tokens. This section will be updated when it lands.
+
+### Client configuration
+
+Most MCP clients accept a server URL and a set of headers. The exact
+configuration format is client-specific; below is the shape of the values to
+plug in:
+
+| Field | Value |
 | --- | --- |
-| `TARGET_ENV` | Whether to run the server in `prod` or `dev` mode. |
-| `REDIS_URL` | The URL of the Redis server. |
-| `MCP_WORKERS` | The number of gunicorn workers to run the server with in `prod` mode. |
-| `COURTLISTENER_API_BASE_URL` | The base URL of the CourtListener API. Defaults to the real CourtListener API base URL, but can be overridden to use a local development API. |
---------------------------------
+| URL | `https://mcp.courtlistener.com/` |
+| Transport | Streamable HTTP |
+| Headers | `Authorization: Token <your-token-here>` |
 
-### Development
+For clients that only support stdio (for example, some older Claude Desktop
+builds), you can bridge to the remote server with
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
 
-Run the server in development mode with Docker Compose. The default environment variables are set in the compose file, so no env config is needed.
-
-```bash
-docker compose up --build
+```json
+{
+  "mcpServers": {
+    "courtlistener": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.courtlistener.com/",
+        "--header",
+        "Authorization: Token ${COURTLISTENER_API_TOKEN}"
+      ],
+      "env": {
+        "COURTLISTENER_API_TOKEN": "your-token-here"
+      }
+    }
+  }
+}
 ```
 
-The server will be available at `http://localhost:8080`.
+### Programmatic access
 
-If you want to point to a local CourtListener instance, you can set the `COURTLISTENER_API_BASE_URL` environment variable to the base URL of the local API. Because the MCP server is running in a Docker container, you can use the `host.docker.internal` hostname to point to your host machine's `localhost`. For example:
-
-```bash
-COURTLISTENER_API_BASE_URL=http://host.docker.internal:8000/api/rest/v4
-```
-
-Here is an example script to make a test tool call to the server:
+If you want to call the server from code — for testing, scripting, or building
+your own agent — use any MCP client library. Here's an example with the
+`fastmcp` Python client:
 
 ```python
 import asyncio
 import os
 
-from dotenv import load_dotenv
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
-
-load_dotenv()
-
-MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://localhost:8080")
-COURTLISTENER_API_TOKEN = os.getenv("COURTLISTENER_API_TOKEN")
 
 
 async def main():
     async with Client(
         transport=StreamableHttpTransport(
-            MCP_SERVER_URL,
-            headers={"Authorization": f"Token {COURTLISTENER_API_TOKEN}"},
+            "https://mcp.courtlistener.com/",
+            headers={
+                "Authorization": f"Token {os.environ['COURTLISTENER_API_TOKEN']}"
+            },
         ),
     ) as client:
         result = await client.call_tool(
-            "get_endpoint_item", {"endpoint_id": "courts", "item_id": "scotus"}
+            "get_endpoint_item",
+            {"endpoint_id": "courts", "item_id": "scotus"},
         )
         print(result)
 
@@ -63,3 +114,134 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+---
+
+## Running the server locally
+
+You can also run the server on your own machine. Two transports are supported.
+
+### stdio (recommended for local desktop clients)
+
+Install the package with the `mcp` extra:
+
+```bash
+pip install 'courtlistener-api-client[mcp]'
+```
+
+That installs a `courtlistener-mcp` console script (defined in
+`pyproject.toml` and backed by `courtlistener.mcp.server:main`) that runs the
+server over stdio — the transport most desktop MCP clients expect for local
+servers.
+
+Authentication in stdio mode uses the `COURTLISTENER_API_TOKEN` environment
+variable (there is no request to attach headers to):
+
+```bash
+export COURTLISTENER_API_TOKEN="your-token-here"
+courtlistener-mcp
+```
+
+A Claude Desktop–style config entry looks like this:
+
+```json
+{
+  "mcpServers": {
+    "courtlistener": {
+      "command": "courtlistener-mcp",
+      "env": {
+        "COURTLISTENER_API_TOKEN": "your-token-here"
+      }
+    }
+  }
+}
+```
+
+stdio mode does not require Redis.
+
+### HTTP (Streamable HTTP, same as the hosted server)
+
+The HTTP app lives at `courtlistener.mcp.app:app` and is served by Uvicorn in
+development or Gunicorn in production. The easiest way to run it is with
+Docker Compose, which also starts a Redis instance for session state:
+
+```bash
+docker compose up --build
+```
+
+The server will be available at `http://localhost:8080/`. Connect to it the
+same way you would connect to the hosted server, passing your token in an
+`Authorization` header.
+
+To point the server at a local CourtListener API instead of the public one,
+set `COURTLISTENER_API_BASE_URL`. Because the MCP server runs inside a
+container, use `host.docker.internal` to reach your host:
+
+```bash
+COURTLISTENER_API_BASE_URL=http://host.docker.internal:8000/api/rest/v4 \
+  docker compose up --build
+```
+
+---
+
+## Development
+
+### Environment variables
+
+| Variable | Used in | Description |
+| --- | --- | --- |
+| `COURTLISTENER_API_TOKEN` | stdio mode | API token used when no `Authorization` header is present. |
+| `COURTLISTENER_API_BASE_URL` | both | Override the CourtListener API base URL. Defaults to the public API; set it to point at a local CourtListener dev instance. |
+| `TARGET_ENV` | HTTP mode (Docker) | `dev` runs Uvicorn with `--reload`; `prod` runs Gunicorn. Set via the `docker-entrypoint.sh` script. |
+| `REDIS_URL` | HTTP mode | Required. URL of the Redis instance used for MCP session state. |
+| `MCP_WORKERS` | HTTP mode, prod | Number of Gunicorn workers. Defaults to `4`. |
+
+### Project layout
+
+The MCP code lives under `courtlistener/mcp/`:
+
+- `server.py` — `create_mcp_server()` builds the FastMCP instance and wires up
+  the tool-dispatch middleware. `main()` is the stdio entrypoint exposed as
+  the `courtlistener-mcp` console script.
+- `app.py` — imports `create_http_app()` from `server.py` and exposes `app`,
+  the ASGI app that Gunicorn/Uvicorn serve.
+- `middleware.py` — dispatches tool calls to the registry.
+- `tools/` — one module per tool, registered in `tools/__init__.py`.
+
+### Running against a local CourtListener
+
+See the `COURTLISTENER_API_BASE_URL` instructions in the HTTP section above.
+The same variable works in stdio mode if you prefer to iterate without Docker.
+
+### Tests and linting
+
+Tests, linting, and type-checking run via `tox`:
+
+```bash
+tox
+```
+
+CI runs the same targets on pull requests.
+
+---
+
+## Deployment
+
+The hosted server is deployed from this repository. The
+[`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) workflow runs on
+every push to `main` and:
+
+1. Builds a production Docker image (`TARGET_ENV=prod`) from the root
+   `Dockerfile` and pushes it to Docker Hub as
+   `freelawproject/courtlistener-mcp:<sha>-prod`.
+2. Force-syncs the `mcp-env` ExternalSecret in the `courtlistener-mcp`
+   namespace so fresh env values land before the rollout.
+3. Rolls out the image to the `mcp-web` deployment in the `courtlistener`
+   EKS cluster and waits for the rollout to complete.
+
+PR labels can skip parts of the pipeline:
+
+| Label | Effect |
+| --- | --- |
+| `skip-deploy` | Skip the build step (and therefore the whole deploy). |
+| `skip-web-deploy` | Build and sync secrets, but don't roll out the new image. |

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -8,8 +8,8 @@ retrieve dockets, analyze citations, manage alerts, and more.
 
 This document covers three things, in order:
 
-1. [Connecting to the hosted server](#connecting-to-the-hosted-server) at
-   `mcp.courtlistener.com` (the option most users want)
+1. ~~[Connecting to the hosted server](#connecting-to-the-hosted-server) at
+   `mcp.courtlistener.com` (the option most users want)~~ — **Coming Soon**
 2. [Running the server locally](#running-the-server-locally) over stdio or HTTP
 3. [Development and deployment](#development) of the server itself
 
@@ -17,11 +17,8 @@ This document covers three things, in order:
 
 ## Connecting to the hosted server
 
-Free Law Project hosts a public instance of this server at:
-
-```
-https://mcp.courtlistener.com/
-```
+~~Free Law Project hosts a public instance of this server at
+`https://mcp.courtlistener.com/`.~~ **(Coming Soon.)**
 
 It speaks the MCP [Streamable HTTP](https://modelcontextprotocol.io/specification/basic/transports#streamable-http)
 transport. Any MCP client that supports Streamable HTTP with custom headers can

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -59,7 +59,10 @@ plug in:
 
 For clients that only support stdio (for example, some older Claude Desktop
 builds), you can bridge to the remote server with
-[`mcp-remote`](https://www.npmjs.com/package/mcp-remote):
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote). In Claude Desktop,
+open the config file via **Settings → Developer → Edit Config** (on macOS
+this file lives at `~/Library/Application Support/Claude/claude_desktop_config.json`;
+on Windows at `%APPDATA%\Claude\claude_desktop_config.json`) and add:
 
 ```json
 {
@@ -112,7 +115,10 @@ export COURTLISTENER_API_TOKEN="your-token-here"
 uvx --from 'courtlistener-api-client[mcp]' courtlistener-mcp
 ```
 
-A Claude Desktop–style config entry looks like this:
+A Claude Desktop–style config entry looks like this. In Claude Desktop,
+open the config file via **Settings → Developer → Edit Config** (on macOS
+this file lives at `~/Library/Application Support/Claude/claude_desktop_config.json`;
+on Windows at `%APPDATA%\Claude\claude_desktop_config.json`):
 
 ```json
 {

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Run with VERSION env variable set; e.g. make push-image -e VERSION=$(git rev-parse --short HEAD)
+# Note that makefiles differentiate between tabs and spaces in a weird way!
+
+# Ensure VERSION is set.
+ifndef VERSION
+$(error VERSION variable is not set. Use -e VERSION=XYZ to proceed.)
+endif
+
+.PHONY: build-image push-image
+
+REPO ?= freelawproject/courtlistener-mcp
+DOCKER_TAG_PROD = $(VERSION)-prod
+UNAME := $(shell uname -m)
+
+build-image:
+	docker build -t $(REPO):$(DOCKER_TAG_PROD) --build-arg TARGET_ENV=prod --build-arg GIT_SHA=$(VERSION) --file Dockerfile .
+
+push-image: build-image
+	$(info Checking if valid architecture)
+	@if [ $(UNAME) != "x86_64" ]; then \
+		echo "Only amd64 machines can push single-architecture builds. This \
+protects against arm64 builds being accidentally deployed to the server (which uses amd64)."; \
+		exit 1; \
+	fi
+
+	    echo "Architecture is OK. Pushing."; \
+	    docker push $(REPO):$(DOCKER_TAG_PROD);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python client for the [CourtListener API](https://www.courtlistener.com/help/api/rest/v4), providing access to millions of legal opinions, dockets, judges, and more from [Free Law Project](https://free.law/).
 
-> **Using an LLM?** This repo also ships the **CourtListener MCP server**, which exposes the API to any [Model Context Protocol](https://modelcontextprotocol.io) client (Claude Desktop, Cursor, etc.). Free Law Project hosts it at [`mcp.courtlistener.com`](https://mcp.courtlistener.com/). See [MCP_README.md](MCP_README.md) for connection details and for running it locally.
+> **Using an LLM?** This repo also ships the **CourtListener MCP server**, which exposes the API to any [Model Context Protocol](https://modelcontextprotocol.io) client (Claude Desktop, Cursor, etc.). ~~Free Law Project hosts it at [`mcp.courtlistener.com`](https://mcp.courtlistener.com/).~~ **(Coming Soon.)** See [MCP_README.md](MCP_README.md) for connection details and for running it locally.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Python client for the [CourtListener API](https://www.courtlistener.com/help/api/rest/v4), providing access to millions of legal opinions, dockets, judges, and more from [Free Law Project](https://free.law/).
 
+> **Using an LLM?** This repo also ships the **CourtListener MCP server**, which exposes the API to any [Model Context Protocol](https://modelcontextprotocol.io) client (Claude Desktop, Cursor, etc.). Free Law Project hosts it at [`mcp.courtlistener.com`](https://mcp.courtlistener.com/). See [MCP_README.md](MCP_README.md) for connection details and for running it locally.
+
 ## Installation
 
 ```bash

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -7,6 +7,9 @@ from starlette.responses import JSONResponse
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
 
 REDIS_URL = os.getenv("REDIS_URL")
+# Baked into production images by the Makefile via a Docker ARG; defaults
+# to "unknown" for local / unparametrized builds.
+GIT_SHA = os.getenv("GIT_SHA", "unknown")
 
 
 def create_mcp_server(**kwargs):
@@ -25,6 +28,7 @@ def create_mcp_server(**kwargs):
         return JSONResponse(
             {
                 "status": "healthy" if all(services.values()) else "unhealthy",
+                "version": GIT_SHA,
                 "services": services,
             }
         )


### PR DESCRIPTION
Fixes #102 

Workflow relies on adding #101 secrets to the repo and finishing the [infra setup](https://github.com/freelawproject/infrastructure/issues/695) 

```
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
```

Names used in the workflow:

| Resource | Name |
| --- | --- |
| EKS namespace | `courtlistener-mcp` |
| Deployment | `mcp-web` |
| Container inside the Deployment | `web` |
| ExternalSecret (syncs from Secrets Manager) | `mcp-env` |
| Docker image | `freelawproject/courtlistener-mcp:<short-sha>-prod` |
| Container port | `8080` |
| Health endpoint (for probes + ALB target-group health) | `GET /health` |
| Subdomain | `mcp.courtlistener.com` |