### PR TITLE
fix(docker): force 1 worker per pod to avoid breaking sessions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Changes:
 - Refactor MCP server to use FastMCP.
 - Make COURTLISTENER_API_BASE_URL configurable via environment variable.
 - Add CI workflow and Makefile for building and deploying the MCP server.
+- Force use of single worker per pod in production.
 
 Fixes:
 -

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -176,7 +176,6 @@ COURTLISTENER_API_BASE_URL=http://host.docker.internal:8000/api/rest/v4 \
 | `COURTLISTENER_API_BASE_URL` | both | Override the CourtListener API base URL. Defaults to the public API; set it to point at a local CourtListener dev instance. |
 | `TARGET_ENV` | HTTP mode (Docker) | `dev` runs Uvicorn with `--reload`; `prod` runs Gunicorn. Set via the `docker-entrypoint.sh` script. |
 | `REDIS_URL` | HTTP mode | Required. URL of the Redis instance used for MCP session state. |
-| `MCP_WORKERS` | HTTP mode, prod | Number of Gunicorn workers. Defaults to `4`. |
 
 ### Project layout
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [ "$TARGET_ENV" = "prod" ]; then
     # Production command
     exec gunicorn \
-        --workers=${MCP_WORKERS:-4} \
+        --workers=1 \
         --worker-class=uvicorn.workers.UvicornWorker \
         --bind=0.0.0.0:8080 \
         --timeout=300 \


### PR DESCRIPTION
MCP requests need to be routed to the same process within a session. We should run with a single worker and scale horizontally with pods. To avoid the same issue across pods we'll need to file a separate issue where we route requests by mcp session id:

```
nginx.ingress.kubernetes.io/upstream-hash-by: "$http_mcp_session_id"
nginx.ingress.kubernetes.io/upstream-hash-by-subset: "false"
```