### PR TITLE
feat(mcp): use redis directly for managing tool state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Required for clients of the CourtListener Python library and for the MCP
+# server in stdio mode.
+COURTLISTENER_API_TOKEN=
+
+# Optional: point the library/MCP server at a non-production CourtListener
+# instance (e.g., a local dev server). Leave unset to use the public API.
+# COURTLISTENER_API_BASE_URL=http://host.docker.internal:8000/api/rest/v4
+
+# Required for the HTTP MCP server. The Docker Compose dev stack wires this
+# automatically; set it explicitly if running the app outside Compose.
+# REDIS_URL=redis://localhost:6379
+
+# HMAC key used to derive per-user cache prefixes in Redis for session-scoped
+# tool state (query pagination, citation analysis jobs). Set to a strong
+# random value in production.
+# MCP_SECRET_KEY=

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Changes:
 - Make COURTLISTENER_API_BASE_URL configurable via environment variable.
 - Add CI workflow and Makefile for building and deploying the MCP server.
 - Force use of single worker per pod in production.
+- Switch MCP server to stateless HTTP. Session-scoped tool state (query pagination, citation analysis jobs) is now stored in Redis under per-user keys derived from an HMAC of the API token, so any worker can serve any request. Adds `MCP_SECRET_KEY` for the HMAC key.
 
 Fixes:
 -

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -176,6 +176,8 @@ COURTLISTENER_API_BASE_URL=http://host.docker.internal:8000/api/rest/v4 \
 | `COURTLISTENER_API_BASE_URL` | both | Override the CourtListener API base URL. Defaults to the public API; set it to point at a local CourtListener dev instance. |
 | `TARGET_ENV` | HTTP mode (Docker) | `dev` runs Uvicorn with `--reload`; `prod` runs Gunicorn. Set via the `docker-entrypoint.sh` script. |
 | `REDIS_URL` | HTTP mode | Required. URL of the Redis instance used for MCP session state. |
+| `MCP_WORKERS` | HTTP mode | Number of Gunicorn workers. Defaults to `4`. |
+| `MCP_SECRET_KEY` | HTTP mode | HMAC key used to derive per-user Redis key prefixes for session-scoped tool state (query pagination, citation analysis jobs). Set to a strong random value in production. |
 
 ### Project layout
 

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -48,8 +48,10 @@ def create_http_app():
     if REDIS_URL is None:
         raise ValueError("REDIS_URL is required for HTTP mode")
     redis_store = RedisStore(url=REDIS_URL)
-    mcp = create_mcp_server(session_state_store=redis_store)
-    return mcp.http_app(path="/")
+    mcp = create_mcp_server(
+        session_state_store=redis_store,
+    )
+    return mcp.http_app(path="/", stateless_http=True)
 
 
 def main():

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -75,104 +75,101 @@ class AnalyzeCitationsTool(MCPTool):
                 "Exactly one of text or opinion ID must be provided."
             )
 
-        if opinion_id is not None:
-            with self.get_client() as client:
+        with self.get_client() as client:
+            if opinion_id is not None:
                 opinion = client.opinions.get(opinion_id)
                 text = opinion.get("plain_text")
                 if not text:
                     raise ValueError("Text not available for opinion ID.")
 
-        # Step 1: Local extraction and resolution
-        assert text is not None  # for mypy
-        cites = get_citations(text)
-        if not cites:
-            return "No citations found."
+            # Step 1: Local extraction and resolution
+            assert text is not None  # for mypy
+            cites = get_citations(text)
+            if not cites:
+                return "No citations found."
 
-        resolutions = resolve_citations(cites)
+            resolutions = resolve_citations(cites)
 
-        # Build per-resource reference info for output
-        resource_refs: dict[str, dict] = {}
-        for resource, cite_list in resolutions.items():
-            if hasattr(resource, "citation"):
-                primary = resource.citation
+            # Build per-resource reference info for output
+            resource_refs: dict[str, dict] = {}
+            for resource, cite_list in resolutions.items():
+                if hasattr(resource, "citation"):
+                    primary = resource.citation
+                    if isinstance(primary, FullCaseCitation):
+                        key = canonical_key(primary)
+                        counts: dict[str, int] = {}
+                        for c in cite_list:
+                            label = citation_type_label(c)
+                            counts[label] = counts.get(label, 0) + 1
+                        total = sum(counts.values())
+                        parts = [f"{v} {k}" for k, v in counts.items()]
+                        breakdown = ", ".join(parts)
+                        resource_refs[key] = {
+                            "ref_count": total,
+                            "ref_breakdown": breakdown,
+                        }
+
+            # Step 2: Get unique case citation strings for API verification
+            unique_citations: list[str] = []
+            seen: set[str] = set()
+            for resource in resolutions:
+                primary = getattr(resource, "citation", None)
                 if isinstance(primary, FullCaseCitation):
                     key = canonical_key(primary)
-                    counts: dict[str, int] = {}
-                    for c in cite_list:
-                        label = citation_type_label(c)
-                        counts[label] = counts.get(label, 0) + 1
-                    total = sum(counts.values())
-                    parts = [f"{v} {k}" for k, v in counts.items()]
-                    breakdown = ", ".join(parts)
-                    resource_refs[key] = {
-                        "ref_count": total,
-                        "ref_breakdown": breakdown,
+                    if key not in seen:
+                        seen.add(key)
+                        unique_citations.append(key)
+
+            # Step 3: Verify via API
+            verified: dict[str, dict] = {}
+
+            # Separate out citations with None page numbers (slip opinions).
+            # These produce keys like "586 U. S. None" which the API cannot
+            # resolve.  Mark them as unresolvable upfront rather than sending
+            # them to the API where they'd silently get no result.
+            sendable: list[str] = []
+            for key in unique_citations:
+                if key.endswith(" None"):
+                    verified[key] = {
+                        "status": None,
+                        "citation": key,
+                        "clusters": [],
+                        "error_message": (
+                            "Slip opinion citation without page number"
+                        ),
                     }
+                else:
+                    sendable.append(key)
 
-        # Step 2: Get unique case citation strings for API verification
-        unique_citations: list[str] = []
-        seen: set[str] = set()
-        for resource in resolutions:
-            primary = getattr(resource, "citation", None)
-            if isinstance(primary, FullCaseCitation):
-                key = canonical_key(primary)
-                if key not in seen:
-                    seen.add(key)
-                    unique_citations.append(key)
+            pending = list(sendable)
 
-        # Step 3: Verify via API
-        verified: dict[str, dict] = {}
-
-        # Separate out citations with None page numbers (slip opinions).
-        # These produce keys like "586 U. S. None" which the API cannot
-        # resolve.  Mark them as unresolvable upfront rather than sending
-        # them to the API where they'd silently get no result.
-        sendable: list[str] = []
-        for key in unique_citations:
-            if key.endswith(" None"):
-                verified[key] = {
-                    "status": None,
-                    "citation": key,
-                    "clusters": [],
-                    "error_message": (
-                        "Slip opinion citation without page number"
-                    ),
-                }
-            else:
-                sendable.append(key)
-
-        pending = list(sendable)
-
-        if sendable:
-            batch = pending[:MAX_CITATIONS_PER_REQUEST]
-            compact_text = build_compact_string(batch)
-
-            with self.get_client() as client:
+            if sendable:
+                batch = pending[:MAX_CITATIONS_PER_REQUEST]
+                compact_text = build_compact_string(batch)
                 results = client.citation_lookup.lookup_text(compact_text)
+                process_api_results(results, batch, verified, pending)
 
-            process_api_results(results, batch, verified, pending)
+            # Step 4: Store in user-scoped session store
+            analysis_id = make_id()
+            await store_session_citation_analysis(
+                analysis_id,
+                {
+                    "resource_refs": resource_refs,
+                    "unique_citations": unique_citations,
+                    "verified": verified,
+                    "pending": pending,
+                },
+                client,
+            )
 
-        # Step 4: Store in session
-        analysis_id = make_id()
-        await store_session_citation_analysis(
-            analysis_id,
-            {
-                "resource_refs": resource_refs,
-                "unique_citations": unique_citations,
-                "verified": verified,
-                "pending": pending,
-            },
-            ctx,
-        )
-
-        # Step 5: Format output
-        output = format_analysis(
-            analysis_id,
-            cites,
-            resolutions,
-            resource_refs,
-            unique_citations,
-            verified,
-            pending,
-        )
-        return output
+            # Step 5: Format output
+            output = format_analysis(
+                analysis_id,
+                cites,
+                resolutions,
+                resource_refs,
+                unique_citations,
+                verified,
+                pending,
+            )
+            return output

--- a/courtlistener/mcp/tools/call_endpoint_tool.py
+++ b/courtlistener/mcp/tools/call_endpoint_tool.py
@@ -70,7 +70,7 @@ class CallEndpointTool(MCPTool):
                     response = resource.list(**query)
 
                     results = collect_results(response, num_results)
-                    query_id = await prepare_query_id(response, ctx)
+                    query_id = await prepare_query_id(response, client)
                     count = prepare_count(
                         response.current_page.count, query_id
                     )

--- a/courtlistener/mcp/tools/get_counts_tool.py
+++ b/courtlistener/mcp/tools/get_counts_tool.py
@@ -36,13 +36,13 @@ class GetCountsTool(MCPTool):
 
     async def __call__(self, arguments: dict, ctx: Context) -> int:
         query_id = arguments["query_id"]
-        data = await get_session_query(query_id, ctx)
-        if data is None:
-            raise ValueError(
-                f"Query ID {query_id!r} not found. The session may have expired, "
-                "please redo the query first."
-            )
         with self.get_client() as client:
+            data = await get_session_query(query_id, client)
+            if data is None:
+                raise ValueError(
+                    f"Query ID {query_id!r} not found. The session may have "
+                    "expired, please redo the query first."
+                )
             response = ResourceIterator.load(client, data["response"])
             count = response.count
             return count

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -58,14 +58,14 @@ class GetMoreResultsTool(MCPTool):
         query_id = arguments["query_id"]
         num_results = arguments.get("num_results", DEFAULT_NUM_RESULTS)
 
-        query = await get_session_query(query_id, ctx)
-        if query is None:
-            raise ValueError(
-                f"Query ID {query_id!r} not found. The session may have expired, "
-                "please redo the query first."
-            )
-
         with self.get_client() as client:
+            query = await get_session_query(query_id, client)
+            if query is None:
+                raise ValueError(
+                    f"Query ID {query_id!r} not found. The session may have "
+                    "expired, please redo the query first."
+                )
+
             response = ResourceIterator.load(client, query["response"])
 
             if not has_more_results(response):
@@ -77,7 +77,7 @@ class GetMoreResultsTool(MCPTool):
             fields = query.get("fields")
             if fields is not None:
                 updated_data["fields"] = fields
-            await store_session_query(query_id, updated_data, ctx)
+            await store_session_query(query_id, updated_data, client)
 
             filtered_results, _ = filter_results_by_fields(results, fields)
 

--- a/courtlistener/mcp/tools/resume_citation_analysis_tool.py
+++ b/courtlistener/mcp/tools/resume_citation_analysis_tool.py
@@ -50,28 +50,28 @@ class ResumeCitationAnalysisTool(MCPTool):
 
     async def __call__(self, arguments: dict, ctx: Context) -> str:
         job_id = arguments["job_id"]
-        job = await get_session_citation_analysis(job_id, ctx)
-
-        if job is None:
-            raise ValueError(
-                f"Job ID {job_id!r} not found. The session may have expired."
-            )
-
-        pending = job["pending"]
-        if not pending:
-            return f"Job {job_id!r} is already complete.  All citations processed."
-
-        # Verify next batch
-        batch = pending[:MAX_CITATIONS_PER_REQUEST]
-        compact_text = build_compact_string(batch)
-
         with self.get_client() as client:
+            job = await get_session_citation_analysis(job_id, client)
+            if job is None:
+                raise ValueError(
+                    f"Job ID {job_id!r} not found. The session may have expired."
+                )
+
+            pending = job["pending"]
+            if not pending:
+                return f"Job {job_id!r} is already complete.  All citations processed."
+
+            # Verify next batch
+            batch = pending[:MAX_CITATIONS_PER_REQUEST]
+            compact_text = build_compact_string(batch)
             results = client.citation_lookup.lookup_text(compact_text)
 
-        previously_verified = set(job["verified"].keys())
-        process_api_results(results, batch, job["verified"], job["pending"])
-        newly_verified = set(job["verified"].keys()) - previously_verified
+            previously_verified = set(job["verified"].keys())
+            process_api_results(
+                results, batch, job["verified"], job["pending"]
+            )
+            newly_verified = set(job["verified"].keys()) - previously_verified
 
-        await store_session_citation_analysis(job_id, job, ctx)
+            await store_session_citation_analysis(job_id, job, client)
 
-        return format_resume(job_id, job, newly_verified)
+            return format_resume(job_id, job, newly_verified)

--- a/courtlistener/mcp/tools/search_tool.py
+++ b/courtlistener/mcp/tools/search_tool.py
@@ -98,7 +98,7 @@ class SearchTool(MCPTool):
             response = client.search.list(**arguments)
             results = collect_results(response, num_results)
 
-            query_id = await prepare_query_id(response, ctx, fields=fields)
+            query_id = await prepare_query_id(response, client, fields=fields)
             count = prepare_count(response.current_page.count, query_id)
             filtered_results, missing_fields = filter_results_by_fields(
                 results, fields

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -1,14 +1,36 @@
+import hashlib
+import hmac
 import json
+import logging
+import os
 import uuid
 from itertools import islice
+from typing import Any
 
+import redis.asyncio as redis
 import tiktoken
-from fastmcp.server.context import Context
 
+from courtlistener import CourtListener
 from courtlistener.resource import ResourceIterator
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_NUM_RESULTS = 20
 MAX_NUM_RESULTS = 100
+
+# Session-scoped keys live in Redis for this long before being evicted.
+SESSION_TTL_SECONDS = 3600
+
+MCP_SECRET_KEY = os.getenv("MCP_SECRET_KEY")
+if not MCP_SECRET_KEY:
+    MCP_SECRET_KEY = "temporarily-insecure"
+    logger.warning(
+        "MCP_SECRET_KEY is not set; falling back to an insecure default. "
+        "Set a strong random value before going to production."
+    )
+MCP_SECRET_BYTES = MCP_SECRET_KEY.encode("utf-8")
+
+redis_client: redis.Redis | None = None
 
 
 def collect_results(
@@ -25,15 +47,15 @@ def collect_results(
 
 async def prepare_query_id(
     response: ResourceIterator,
-    ctx: Context,
+    client: CourtListener,
     fields: list[str] | None = None,
 ) -> str:
-    """Store query response in session and return a short UUID query ID."""
+    """Store query response in Redis and return a short UUID query ID."""
     query_id = make_id()
     data: dict = {"response": response.dump()}
     if fields is not None:
         data["fields"] = fields
-    await store_session_query(query_id, data, ctx)
+    await store_session_query(query_id, data, client)
     return query_id
 
 
@@ -126,26 +148,82 @@ def prepare_has_more_str(
     return None
 
 
-# Session store helpers
+# User-scoped Redis session helpers.
+#
+# Keyed by an HMAC of the caller's API token rather than the MCP session id,
+# so state survives across stateless_http=True requests and across workers.
+def get_redis() -> redis.Redis:
+    """Lazily build a module-level async Redis client from REDIS_URL."""
+    global redis_client
+    if redis_client is None:
+        url = os.environ.get("REDIS_URL")
+        if not url:
+            raise RuntimeError(
+                "REDIS_URL is not set; cannot access session store."
+            )
+        redis_client = redis.from_url(url, decode_responses=True)
+    return redis_client
+
+
+def user_hash(client: CourtListener) -> str:
+    """Derive an opaque per-user key prefix from the client's API token.
+
+    HMAC-SHA256 with MCP_SECRET_KEY so raw tokens can't be recovered from
+    Redis keys, even by someone with read access to the store.
+    """
+    token = client.api_token
+    if not token:
+        raise ValueError("Client has no API token; cannot derive user hash.")
+    return hmac.new(
+        MCP_SECRET_BYTES, token.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def redis_key(client: CourtListener, suffix: str) -> str:
+    return f"mcp:{user_hash(client)}:{suffix}"
+
+
 def make_id() -> str:
+    """Generate a short, random UUID for session-scoped tool state."""
     return str(uuid.uuid4())[:8]
 
 
-async def get_session_query(query_id: str, ctx: Context) -> dict | None:
-    return await ctx.get_state(f"query:{query_id}")
+async def set_user_scoped(
+    client: CourtListener, suffix: str, value: Any
+) -> None:
+    await get_redis().set(
+        redis_key(client, suffix),
+        json.dumps(value),
+        ex=SESSION_TTL_SECONDS,
+    )
 
 
-async def store_session_query(query_id: str, data: dict, ctx: Context) -> None:
-    await ctx.set_state(f"query:{query_id}", data)
+async def get_user_scoped(client: CourtListener, suffix: str) -> Any:
+    raw = await get_redis().get(redis_key(client, suffix))
+    if raw is None:
+        return None
+    return json.loads(raw)
+
+
+async def get_session_query(
+    query_id: str, client: CourtListener
+) -> dict | None:
+    return await get_user_scoped(client, f"query:{query_id}")
+
+
+async def store_session_query(
+    query_id: str, data: dict, client: CourtListener
+) -> None:
+    await set_user_scoped(client, f"query:{query_id}", data)
 
 
 async def get_session_citation_analysis(
-    job_id: str, ctx: Context
+    job_id: str, client: CourtListener
 ) -> dict | None:
-    return await ctx.get_state(f"citation:{job_id}")
+    return await get_user_scoped(client, f"citation:{job_id}")
 
 
 async def store_session_citation_analysis(
-    job_id: str, data: dict, ctx: Context
+    job_id: str, data: dict, client: CourtListener
 ) -> None:
-    await ctx.set_state(f"citation:{job_id}", data)
+    await set_user_scoped(client, f"citation:{job_id}", data)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       TARGET_ENV: dev
       REDIS_URL: redis://redis:6379
       COURTLISTENER_API_BASE_URL: ${COURTLISTENER_API_BASE_URL:-}
+      MCP_SECRET_KEY: dev-insecure-do-not-use-in-production
     healthcheck:
       test: [
         "CMD", "python", "-c",

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [ "$TARGET_ENV" = "prod" ]; then
     # Production command
     exec gunicorn \
-        --workers=1 \
+        --workers=${MCP_WORKERS:-4} \
         --worker-class=uvicorn.workers.UvicornWorker \
         --bind=0.0.0.0:8080 \
         --timeout=300 \


### PR DESCRIPTION
Fixes #109 


To fix we:

1. Make the MCP stateless
2. For the tool utilities, instead of passing ctx, we pass the courtlistener client instance.
3. We add a helper method that takes a client object and generates a unique user hash (start with access_token and fall back to api_token). Use a secret key for salt.
4. In each of the store and get helper methods, we first generate a user hash, then store or get directly from redis, using the existing keys prepended by the user hash.