### PR TITLE
Add OAuth to MCP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,14 @@ Features:
 - Report the image version (Git SHA) on the MCP `/health` endpoint.
 - Add gunicorn as an `mcp` optional dependency for running the MCP server in production.
 - Add Redis session state store to MCP server.
+- Accept OAuth 2.0 bearer tokens in the MCP HTTP transport (gated on
+  `MCP_REQUIRE_OAUTH`) and forward them to the CourtListener API as
+  `Authorization: Bearer <token>`. Adds an `access_token` parameter
+  to `CourtListener` for Bearer auth. Publishes RFC 9728
+  protected-resource metadata pointing clients at the CourtListener
+  authorization server, but defers token validation itself to CL —
+  the MCP is a thin proxy and CL's OAuth2Authentication is the
+  authoritative check.
 
 Changes:
 - Update pre-commit hooks to latest versions.

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -178,6 +178,9 @@ COURTLISTENER_API_BASE_URL=http://host.docker.internal:8000/api/rest/v4 \
 | `REDIS_URL` | HTTP mode | Required. URL of the Redis instance used for MCP session state. |
 | `MCP_WORKERS` | HTTP mode | Number of Gunicorn workers. Defaults to `4`. |
 | `MCP_SECRET_KEY` | HTTP mode | HMAC key used to derive per-user Redis key prefixes for session-scoped tool state (query pagination, citation analysis jobs). Set to a strong random value in production. |
+| `MCP_REQUIRE_OAUTH` | HTTP mode | When set to the literal string `true` (case-insensitive), the HTTP MCP app accepts OAuth bearer tokens and publishes RFC 9728 protected-resource metadata. Token validation itself is delegated to the CourtListener API. Any other value leaves OAuth off and falls back to legacy `Authorization: Token <api_token>` auth. Defaults to `true`. |
+| `MCP_BASE_URL` | HTTP mode + OAuth | Public URL of the MCP server, used for `/.well-known/oauth-protected-resource`. Defaults to `https://mcp.courtlistener.com` (set to `http://localhost:8080` in `docker-compose.yml`). |
+| `COURTLISTENER_OAUTH_ISSUER` | HTTP mode + OAuth | URL of the OAuth authorization server clients should register with. Advertised in `/.well-known/oauth-protected-resource`. Defaults to `https://www.courtlistener.com`. |
 
 ### Project layout
 

--- a/courtlistener/client.py
+++ b/courtlistener/client.py
@@ -22,21 +22,31 @@ class CourtListener:
     def __init__(
         self,
         api_token: str | None = None,
+        access_token: str | None = None,
         base_url: str | None = None,
         timeout: float = 300.0,
     ) -> None:
         """Initialize the CourtListener client.
 
         Args:
-            api_token: CourtListener API token. If not provided, will look for
-                COURTLISTENER_API_TOKEN environment variable.
+            api_token: CourtListener API token, sent as
+                ``Authorization: Token <api_token>``. If not provided and
+                ``access_token`` is also not provided, will look for the
+                ``COURTLISTENER_API_TOKEN`` environment variable.
+            access_token: OAuth2 access token, sent as
+                ``Authorization: Bearer <access_token>``. When set, it
+                takes precedence over ``api_token`` and the env var.
             base_url: Base URL for the CourtListener API.
             timeout: Request timeout in seconds.
         """
-        self.api_token = api_token or os.environ.get("COURTLISTENER_API_TOKEN")
-        if not self.api_token:
+        self.api_token = api_token or (
+            None if access_token else os.environ.get("COURTLISTENER_API_TOKEN")
+        )
+        self.access_token = access_token
+        if not self.api_token and not self.access_token:
             raise ValueError(
-                "API token is required. Provide it directly or set COURTLISTENER_API_TOKEN "
+                "Authentication is required. Provide api_token, "
+                "access_token, or set COURTLISTENER_API_TOKEN "
                 "environment variable."
             )
 
@@ -97,10 +107,14 @@ class CourtListener:
     def client(self) -> httpx.Client:
         """Get or create the HTTP client."""
         if self._http_client is None:
+            if self.access_token:
+                auth_header = f"Bearer {self.access_token}"
+            else:
+                auth_header = f"Token {self.api_token}"
             self._http_client = httpx.Client(
                 base_url=self.base_url,
                 headers={
-                    "Authorization": f"Token {self.api_token}",
+                    "Authorization": auth_header,
                 },
                 timeout=self.timeout,
             )

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -1,6 +1,12 @@
 import os
 
 from fastmcp import FastMCP
+from fastmcp.server.auth.auth import (
+    AccessToken,
+    AuthProvider,
+    RemoteAuthProvider,
+    TokenVerifier,
+)
 from fastmcp.server.middleware.caching import ResponseCachingMiddleware
 from key_value.aio.stores.redis import RedisStore
 from starlette.responses import JSONResponse
@@ -8,9 +14,47 @@ from starlette.responses import JSONResponse
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
 
 REDIS_URL = os.getenv("REDIS_URL")
-# Baked into production images by the Makefile via a Docker ARG; defaults
-# to "unknown" for local / unparametrized builds.
+
 GIT_SHA = os.getenv("GIT_SHA", "unknown")
+
+OAUTH_ISSUER = os.getenv(
+    "COURTLISTENER_OAUTH_ISSUER", "https://www.courtlistener.com"
+)
+MCP_BASE_URL = os.getenv("MCP_BASE_URL", "https://mcp.courtlistener.com")
+
+
+class PassThroughTokenVerifier(TokenVerifier):
+    """Accept any non-empty bearer token without local validation.
+
+    Known limitation: a bearer token that CL later rejects (expired or
+    revoked mid-session) surfaces as a tool-level error rather than an
+    HTTP 401 from the MCP, so clients won't automatically re-run the
+    OAuth flow. Proactive refresh-token handling in MCP clients covers
+    the common case; revisit with explicit 401 translation if the edge
+    case starts biting in practice.
+    """
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not token:
+            return None
+        # ``client_id`` is required by AccessToken but unused on our
+        # path; CL resolves the real client/user from the token itself.
+        return AccessToken(
+            token=token,
+            client_id="courtlistener-mcp-passthrough",
+            scopes=[],
+        )
+
+
+def build_auth() -> AuthProvider | None:
+    """Return an ``AuthProvider`` when OAuth is configured, else ``None``."""
+    if os.getenv("MCP_REQUIRE_OAUTH", "true").lower() != "true":
+        return None
+    return RemoteAuthProvider(
+        token_verifier=PassThroughTokenVerifier(base_url=MCP_BASE_URL),
+        authorization_servers=[OAUTH_ISSUER],
+        base_url=MCP_BASE_URL,
+    )
 
 
 def create_mcp_server(**kwargs):
@@ -50,6 +94,7 @@ def create_http_app():
     redis_store = RedisStore(url=REDIS_URL)
     mcp = create_mcp_server(
         session_state_store=redis_store,
+        auth=build_auth(),
     )
     return mcp.http_app(path="/", stateless_http=True)
 

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp.server.context import Context
-from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.dependencies import get_access_token, get_http_request
 from fastmcp.tools import Tool
 from mcp.types import ToolAnnotations
 
@@ -15,23 +15,37 @@ class MCPTool:
     annotations: ToolAnnotations | None = None
 
     def get_client(self) -> CourtListener:
-        """Get a CourtListener client with the appropriate API token.
+        """Build a CourtListener client for the current request.
 
-        Token resolution:
-        - HTTP mode: reads from ContextVar (set by AuthMiddleware
-          from the Authorization header)
-        - stdio mode: falls back to COURTLISTENER_API_TOKEN env var
-          (handled by CourtListener constructor)
+        Resolution order:
+        1. HTTP + OAuth mode: use the OAuth access token FastMCP
+           accepted via the pass-through verifier. Forwarded to the CL
+           API as ``Authorization: Bearer <jwt>``, which CL accepts
+           because ``OAuth2Authentication`` is registered in its
+           ``DEFAULT_AUTHENTICATION_CLASSES``.
+        2. HTTP + legacy mode: ``Authorization: Token <api_token>``
+           header (existing stdio-over-HTTP / testing path).
+        3. stdio mode: ``COURTLISTENER_API_TOKEN`` env var, resolved
+           by the ``CourtListener`` constructor.
         """
-        request = get_http_request()
-        auth = request.headers.get("Authorization")
+        # 1. OAuth bearer token (HTTP + auth provider active)
+        access_token = get_access_token()
+        if access_token is not None:
+            return CourtListener(access_token=access_token.token)
 
-        token = None
-        if auth is not None and auth.startswith("Token "):
-            token = auth[len("Token ") :] or None
+        # 2. Legacy "Token ..." header pass-through (no OAuth).
+        #    get_http_request() raises when called outside an HTTP
+        #    request (e.g. stdio mode), so guard against that.
+        try:
+            request = get_http_request()
+        except RuntimeError:
+            request = None
+        if request is not None:
+            auth = request.headers.get("Authorization")
+            if auth and auth.startswith("Token "):
+                return CourtListener(api_token=auth[len("Token ") :] or None)
 
-        if token:
-            return CourtListener(api_token=token)
+        # 3. stdio mode — env var
         return CourtListener()
 
     def get_tool(self) -> Tool:

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -166,14 +166,21 @@ def get_redis() -> redis.Redis:
 
 
 def user_hash(client: CourtListener) -> str:
-    """Derive an opaque per-user key prefix from the client's API token.
+    """Derive an opaque per-user key prefix from the client's credential.
 
     HMAC-SHA256 with MCP_SECRET_KEY so raw tokens can't be recovered from
-    Redis keys, even by someone with read access to the store.
+    Redis keys, even by someone with read access to the store. Uses the
+    OAuth ``access_token`` when present, otherwise the legacy ``api_token``.
+
+    Known limitation: OAuth access tokens rotate, so session state
+    (pagination, citation analysis jobs) will appear to belong to a
+    different user after a refresh and be orphaned until the TTL
+    expires. Tracked separately; a stable user identifier would be a
+    cleaner key.
     """
-    token = client.api_token
+    token = client.access_token or client.api_token
     if not token:
-        raise ValueError("Client has no API token; cannot derive user hash.")
+        raise ValueError("Client has no credential; cannot derive user hash.")
     return hmac.new(
         MCP_SECRET_BYTES, token.encode("utf-8"), hashlib.sha256
     ).hexdigest()

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -23,7 +23,7 @@ SESSION_TTL_SECONDS = 3600
 
 MCP_SECRET_KEY = os.getenv("MCP_SECRET_KEY")
 if not MCP_SECRET_KEY:
-    MCP_SECRET_KEY = "temporarily-insecure"
+    MCP_SECRET_KEY = "insecure-do-not-use-in-production"
     logger.warning(
         "MCP_SECRET_KEY is not set; falling back to an insecure default. "
         "Set a strong random value before going to production."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       REDIS_URL: redis://redis:6379
       COURTLISTENER_API_BASE_URL: ${COURTLISTENER_API_BASE_URL:-}
       MCP_SECRET_KEY: dev-insecure-do-not-use-in-production
+      MCP_REQUIRE_OAUTH: ${MCP_REQUIRE_OAUTH:-true}
+      MCP_BASE_URL: ${MCP_BASE_URL:-http://localhost:8080}
+      COURTLISTENER_OAUTH_ISSUER: ${COURTLISTENER_OAUTH_ISSUER:-https://www.courtlistener.com}
     healthcheck:
       test: [
         "CMD", "python", "-c",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,293 @@
+"""Tests for authentication plumbing: Bearer vs Token headers in
+``CourtListener.client`` and the three-way resolution in
+``MCPTool.get_client``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from courtlistener import CourtListener
+
+
+class TestClientAuthHeader:
+    def test_api_token_uses_token_scheme(self):
+        """``api_token=`` → ``Authorization: Token <token>``."""
+        cl = CourtListener(api_token="secret-api-token")
+        assert cl.client.headers["Authorization"] == "Token secret-api-token"
+
+    def test_access_token_uses_bearer_scheme(self):
+        """``access_token=`` → ``Authorization: Bearer <token>``."""
+        cl = CourtListener(access_token="oauth-jwt")
+        assert cl.client.headers["Authorization"] == "Bearer oauth-jwt"
+
+    def test_access_token_takes_precedence_over_env(self):
+        """``access_token`` wins over ``COURTLISTENER_API_TOKEN``."""
+        with patch.dict(
+            "os.environ", {"COURTLISTENER_API_TOKEN": "env-token"}
+        ):
+            cl = CourtListener(access_token="oauth-jwt")
+        assert cl.access_token == "oauth-jwt"
+        assert cl.api_token is None
+        assert cl.client.headers["Authorization"] == "Bearer oauth-jwt"
+
+    def test_env_var_fallback(self):
+        """No explicit creds → fall back to env var with Token scheme."""
+        with patch.dict(
+            "os.environ", {"COURTLISTENER_API_TOKEN": "env-token"}
+        ):
+            cl = CourtListener()
+        assert cl.client.headers["Authorization"] == "Token env-token"
+
+    def test_missing_credentials_raises(self):
+        """No creds and no env var → ValueError."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            pytest.raises(ValueError, match="Authentication is required"),
+        ):
+            CourtListener()
+
+    def test_explicit_api_token_beats_env(self):
+        """Explicit ``api_token`` wins over the env var."""
+        with patch.dict(
+            "os.environ", {"COURTLISTENER_API_TOKEN": "env-token"}
+        ):
+            cl = CourtListener(api_token="explicit")
+        assert cl.client.headers["Authorization"] == "Token explicit"
+
+
+class TestMCPToolGetClient:
+    """``MCPTool.get_client`` picks the right credential source."""
+
+    def _get_tool(self):
+        # Import lazily so tests don't require optional MCP deps to load.
+        from courtlistener.mcp.tools.mcp_tool import MCPTool
+
+        return MCPTool()
+
+    def test_oauth_bearer_when_access_token_present(self):
+        """With a FastMCP AccessToken available, use Bearer auth."""
+        tool = self._get_tool()
+        fake_token = MagicMock()
+        fake_token.token = "oauth-jwt"
+        with (
+            patch(
+                "courtlistener.mcp.tools.mcp_tool.get_access_token",
+                return_value=fake_token,
+            ),
+            patch(
+                "courtlistener.mcp.tools.mcp_tool.get_http_request"
+            ) as mock_req,
+        ):
+            cl = tool.get_client()
+        # The access-token path short-circuits before we touch the
+        # HTTP request, so get_http_request should not be consulted.
+        mock_req.assert_not_called()
+        assert cl.access_token == "oauth-jwt"
+        assert cl.client.headers["Authorization"] == "Bearer oauth-jwt"
+
+    def test_legacy_token_header_pass_through(self):
+        """No OAuth token, but an ``Authorization: Token …`` header → Token."""
+        tool = self._get_tool()
+        request = MagicMock()
+        request.headers = {"Authorization": "Token legacy-api-token"}
+        with (
+            patch(
+                "courtlistener.mcp.tools.mcp_tool.get_access_token",
+                return_value=None,
+            ),
+            patch(
+                "courtlistener.mcp.tools.mcp_tool.get_http_request",
+                return_value=request,
+            ),
+        ):
+            cl = tool.get_client()
+        assert cl.api_token == "legacy-api-token"
+        assert cl.access_token is None
+        assert cl.client.headers["Authorization"] == "Token legacy-api-token"
+
+    def test_stdio_mode_env_var(self):
+        """No OAuth, no HTTP request → env var."""
+        tool = self._get_tool()
+        with (
+            patch(
+                "courtlistener.mcp.tools.mcp_tool.get_access_token",
+                return_value=None,
+            ),
+            patch(
+                "courtlistener.mcp.tools.mcp_tool.get_http_request",
+                side_effect=RuntimeError("no HTTP request"),
+            ),
+            patch.dict(
+                "os.environ",
+                {"COURTLISTENER_API_TOKEN": "env-api-token"},
+            ),
+        ):
+            cl = tool.get_client()
+        assert cl.api_token == "env-api-token"
+        assert cl.access_token is None
+        assert cl.client.headers["Authorization"] == "Token env-api-token"
+
+    def test_http_mode_without_auth_header_falls_back_to_env(self):
+        """HTTP request present but no Authorization header → env var."""
+        tool = self._get_tool()
+        request = MagicMock()
+        request.headers = {}
+        with (
+            patch(
+                "courtlistener.mcp.tools.mcp_tool.get_access_token",
+                return_value=None,
+            ),
+            patch(
+                "courtlistener.mcp.tools.mcp_tool.get_http_request",
+                return_value=request,
+            ),
+            patch.dict(
+                "os.environ",
+                {"COURTLISTENER_API_TOKEN": "env-api-token"},
+            ),
+        ):
+            cl = tool.get_client()
+        assert cl.client.headers["Authorization"] == "Token env-api-token"
+
+
+class TestServerAuthWiring:
+    """``build_auth`` activates when ``MCP_REQUIRE_OAUTH`` is set to "true",
+    and ``create_mcp_server`` itself never pulls auth from the
+    environment — the HTTP factory is the only caller that does."""
+
+    def test_build_auth_returns_verifier_when_set(self):
+        """OAuth on → returns a RemoteAuthProvider that publishes the
+        RFC 9728 protected-resource metadata, wrapping the pass-through
+        verifier. Token validation itself is delegated downstream to
+        CL's OAuth2Authentication when the tool code forwards the
+        bearer to the CourtListener API.
+        """
+        from fastmcp.server.auth.auth import RemoteAuthProvider
+
+        with patch.dict(
+            "os.environ",
+            {
+                "MCP_REQUIRE_OAUTH": "true",
+                "COURTLISTENER_OAUTH_ISSUER": "https://example.test",
+                "MCP_BASE_URL": "https://mcp.example.test",
+            },
+        ):
+            # Reload so module-level constants pick up the patched env.
+            # Re-read the class from the reloaded module so isinstance()
+            # sees the new class object, not a stale reference.
+            import importlib
+
+            import courtlistener.mcp.server as server_mod
+
+            importlib.reload(server_mod)
+            auth = server_mod.build_auth()
+            verifier_cls = server_mod.PassThroughTokenVerifier
+        assert isinstance(auth, RemoteAuthProvider)
+        assert isinstance(auth.token_verifier, verifier_cls)
+        # Discovery route is advertised so clients can find the auth
+        # server without the MCP having to serve
+        # .well-known/oauth-authorization-server itself.
+        routes = auth.get_routes(mcp_path="/")
+        paths = {getattr(r, "path", None) for r in routes}
+        assert "/.well-known/oauth-protected-resource" in paths
+
+    def test_pass_through_verifier_accepts_any_non_empty_token(self):
+        """Non-empty bearer tokens are accepted without local checks;
+        CL is the authoritative validator downstream.
+        """
+        import asyncio
+
+        from courtlistener.mcp.server import PassThroughTokenVerifier
+
+        verifier = PassThroughTokenVerifier(
+            base_url="https://mcp.example.test"
+        )
+        token = asyncio.run(verifier.verify_token("anything-goes"))
+        assert token is not None
+        assert token.token == "anything-goes"
+
+    def test_pass_through_verifier_rejects_empty_token(self):
+        """Empty bearer → not authenticated. Prevents trivially-empty
+        ``Authorization: Bearer`` headers from slipping through.
+        """
+        import asyncio
+
+        from courtlistener.mcp.server import PassThroughTokenVerifier
+
+        verifier = PassThroughTokenVerifier(
+            base_url="https://mcp.example.test"
+        )
+        assert asyncio.run(verifier.verify_token("")) is None
+
+    def test_build_auth_accepts_true_case_insensitively(self):
+        """``MCP_REQUIRE_OAUTH=TRUE`` / ``True`` also enables OAuth."""
+        from courtlistener.mcp.server import build_auth
+
+        for value in ("true", "TRUE", "True"):
+            with patch.dict("os.environ", {"MCP_REQUIRE_OAUTH": value}):
+                assert build_auth() is not None, value
+
+    def test_build_auth_ignores_other_truthy_values(self):
+        """Only the literal string ``true`` (any casing) enables OAuth.
+
+        Prevents accidental activation from stray values like ``1`` or
+        ``yes`` in deployment configs.
+        """
+        from courtlistener.mcp.server import build_auth
+
+        for value in ("1", "yes", "on", "True ", " true", "false", ""):
+            with patch.dict("os.environ", {"MCP_REQUIRE_OAUTH": value}):
+                assert build_auth() is None, value
+
+    def test_create_mcp_server_does_not_enable_auth_by_default(self):
+        """Bare ``create_mcp_server`` should not wire in OAuth, even
+        when ``MCP_REQUIRE_OAUTH`` is set — only the HTTP factory does.
+        """
+        from courtlistener.mcp.server import create_mcp_server
+
+        with patch.dict("os.environ", {"MCP_REQUIRE_OAUTH": "true"}):
+            mcp = create_mcp_server()
+        # FastMCP exposes its auth provider via ``auth`` (or ``_auth``
+        # depending on version); both should be falsy here.
+        auth = getattr(mcp, "auth", None) or getattr(mcp, "_auth", None)
+        assert not auth
+
+
+class TestHealthEndpoint:
+    """``/health`` must stay unauthenticated so uptime checks keep
+    working even when OAuth is enabled on the MCP routes."""
+
+    def test_health_is_unauthenticated_under_oauth(self):
+        """GET /health returns 200 with no Authorization header, even
+        when the HTTP app has an OAuth ``AuthProvider`` attached."""
+        from starlette.testclient import TestClient
+
+        # Skip the RedisStore wiring (create_http_app requires Redis);
+        # we only care that /health routes through FastMCP's starlette
+        # app unauthenticated. Build the server the same way
+        # create_http_app does — auth via build_auth().
+        with patch.dict(
+            "os.environ",
+            {
+                "MCP_REQUIRE_OAUTH": "true",
+                "COURTLISTENER_OAUTH_ISSUER": "https://example.test",
+                "MCP_BASE_URL": "https://mcp.example.test",
+            },
+        ):
+            import importlib
+
+            import courtlistener.mcp.server as server_mod
+
+            importlib.reload(server_mod)
+            mcp = server_mod.create_mcp_server(auth=server_mod.build_auth())
+
+        app = mcp.http_app(path="/")
+        with TestClient(app) as http_client:
+            response = http_client.get("/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "healthy"
+        assert body["services"] == {"mcp": True}


### PR DESCRIPTION
Fixes #111 

Adds OAuth to the MCP. We implement a passthrough verifier since the token is verified by CourtListener. The client, user_hash for scoping session data, and MCP tool client loader, are all wired up to use the access_token when available.