### PR TITLE
feat(mcp): verify OAuth tokens via OIDC userinfo + stable user hash

### DIFF
--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -1,11 +1,17 @@
 import json
 
+from fastmcp.exceptions import ToolError
+from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 from mcp.types import TextContent
 
+from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools import MCP_TOOLS
-from courtlistener.mcp.tools.utils import json_default
+from courtlistener.mcp.tools.utils import (
+    invalidate_token_cache,
+    json_default,
+)
 
 
 class ToolHandlerMiddleware(Middleware):
@@ -23,7 +29,34 @@ class ToolHandlerMiddleware(Middleware):
         ctx = context.fastmcp_context
         if ctx is None:
             raise ValueError("No context found")
-        result = await mcp_tool(arguments, ctx)
+
+        try:
+            result = await mcp_tool(arguments, ctx)
+        except CourtListenerAPIError as exc:
+            if exc.status_code == 401:
+                # CL rejected a token our verifier previously accepted
+                # (revoked or rotated mid-cache). Drop the cache entry so
+                # the next MCP request re-runs userinfo, fails verification,
+                # and gets a proper HTTP 401 from the auth middleware —
+                # which is what triggers the client's OAuth refresh flow.
+                #
+                # We can't emit the 401 for *this* request from inside the
+                # tool handler (the HTTP response has already committed to
+                # 200 for the JSON-RPC envelope). The tool-level error
+                # below is the best we can do here; the follow-up request
+                # gets the clean signal.
+                try:
+                    access_token = get_access_token()
+                except RuntimeError:
+                    access_token = None
+                if access_token is not None:
+                    await invalidate_token_cache(access_token.token)
+                raise ToolError(
+                    "CourtListener rejected the request as unauthorized. "
+                    "Your session may have expired; retry to re-authenticate."
+                ) from exc
+            raise
+
         if isinstance(result, dict):
             result = json.dumps(result, default=json_default, indent=2)
         if isinstance(result, str):

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -9,6 +9,7 @@ from fastmcp.server.auth.auth import (
 )
 from fastmcp.server.middleware.caching import ResponseCachingMiddleware
 from key_value.aio.stores.redis import RedisStore
+from pydantic import AnyHttpUrl
 from starlette.responses import JSONResponse
 
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
@@ -17,29 +18,56 @@ from courtlistener.mcp.tools.utils import (
     MCP_BASE_URL,
     OAUTH_ISSUER,
     REDIS_URL,
+    resolve_user_hash_via_userinfo,
 )
 
 
-class PassThroughTokenVerifier(TokenVerifier):
-    """Accept any non-empty bearer token without local validation.
+class UserInfoTokenVerifier(TokenVerifier):
+    """Verify OAuth tokens by calling CL's OIDC userinfo endpoint.
 
-    Known limitation: a bearer token that CL later rejects (expired or
-    revoked mid-session) surfaces as a tool-level error rather than an
-    HTTP 401 from the MCP, so clients won't automatically re-run the
-    OAuth flow. Proactive refresh-token handling in MCP clients covers
-    the common case; revisit with explicit 401 translation if the edge
-    case starts biting in practice.
+    Caches token→user_hash mappings in Redis so a burst of tool calls
+    from one session collapses to a single userinfo round-trip. The
+    cached ``user_hash`` is a stable HMAC of the OIDC ``sub`` claim, so
+    session state in Redis survives access-token rotation (previously,
+    a refresh silently orphaned the user's namespace).
+
+    Revocation semantics:
+    - A freshly-rejected token surfaces here as a 401 from userinfo →
+      ``verify_token`` returns ``None`` → the auth middleware sends a
+      proper 401 with ``WWW-Authenticate`` so the MCP client re-auths.
+    - A token revoked mid-cache keeps working until the TTL expires or
+      until ``ToolHandlerMiddleware`` sees a 401 from a downstream CL
+      API call, invalidates the cache entry, and forces re-verification
+      on the next request.
+
+    Required scopes (advertised in the protected-resource metadata so
+    MCP clients include them in the authorize request):
+    - ``openid``: needed by DOT's ``/o/userinfo/`` endpoint.
+    - ``api``: CL's custom scope for REST API access.
     """
+
+    def __init__(self, *, base_url: str) -> None:
+        super().__init__(
+            base_url=base_url,
+            required_scopes=["openid", "api"],
+        )
 
     async def verify_token(self, token: str) -> AccessToken | None:
         if not token:
             return None
-        # ``client_id`` is required by AccessToken but unused on our
-        # path; CL resolves the real client/user from the token itself.
+        user_hash = await resolve_user_hash_via_userinfo(token)
+        if user_hash is None:
+            return None
+        # Userinfo doesn't return the token's scopes, but a 200 from it
+        # proves the token carries ``openid`` (DOT enforces that). The
+        # ``api`` scope is enforced downstream by CL's REST API itself.
+        # Echoing the required set back here satisfies the middleware's
+        # scope check without a second round-trip to introspection.
         return AccessToken(
             token=token,
-            client_id="courtlistener-mcp-passthrough",
-            scopes=[],
+            client_id="courtlistener-mcp",
+            scopes=list(self.required_scopes),
+            claims={"user_hash": user_hash},
         )
 
 
@@ -48,8 +76,8 @@ def build_auth() -> AuthProvider | None:
     if os.getenv("MCP_REQUIRE_OAUTH", "true").lower() != "true":
         return None
     return RemoteAuthProvider(
-        token_verifier=PassThroughTokenVerifier(base_url=MCP_BASE_URL),
-        authorization_servers=[OAUTH_ISSUER],  # type: ignore[list-item]
+        token_verifier=UserInfoTokenVerifier(base_url=MCP_BASE_URL),
+        authorization_servers=[AnyHttpUrl(OAUTH_ISSUER)],
         base_url=MCP_BASE_URL,
     )
 

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -12,15 +12,12 @@ from key_value.aio.stores.redis import RedisStore
 from starlette.responses import JSONResponse
 
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
-
-REDIS_URL = os.getenv("REDIS_URL")
-
-GIT_SHA = os.getenv("GIT_SHA", "unknown")
-
-OAUTH_ISSUER = os.getenv(
-    "COURTLISTENER_OAUTH_ISSUER", "https://www.courtlistener.com"
+from courtlistener.mcp.tools.utils import (
+    GIT_SHA,
+    MCP_BASE_URL,
+    OAUTH_ISSUER,
+    REDIS_URL,
 )
-MCP_BASE_URL = os.getenv("MCP_BASE_URL", "https://mcp.courtlistener.com")
 
 
 class PassThroughTokenVerifier(TokenVerifier):

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -8,8 +8,10 @@ from datetime import date, datetime
 from itertools import islice
 from typing import Any
 
+import httpx
 import redis.asyncio as redis
 import tiktoken
+from fastmcp.server.dependencies import get_access_token
 
 from courtlistener import CourtListener
 from courtlistener.resource import ResourceIterator
@@ -22,6 +24,9 @@ MAX_NUM_RESULTS = 100
 # Session-scoped keys live in Redis for this long before being evicted.
 SESSION_TTL_SECONDS = 3600
 
+# How long a token→user_hash mapping is cached.
+TOKEN_CACHE_TTL_SECONDS = int(os.getenv("MCP_TOKEN_CACHE_TTL", "600"))
+
 REDIS_URL = os.getenv("REDIS_URL")
 
 GIT_SHA = os.getenv("GIT_SHA", "unknown")
@@ -30,6 +35,11 @@ MCP_BASE_URL = os.getenv("MCP_BASE_URL", "https://mcp.courtlistener.com")
 
 OAUTH_ISSUER = os.getenv(
     "COURTLISTENER_OAUTH_ISSUER", "https://www.courtlistener.com"
+)
+
+OAUTH_USERINFO_URL = os.getenv(
+    "COURTLISTENER_OAUTH_USERINFO_URL",
+    f"{OAUTH_ISSUER.rstrip('/')}/o/userinfo/",
 )
 
 MCP_SECRET_KEY = os.getenv("MCP_SECRET_KEY")
@@ -182,25 +192,100 @@ def get_redis() -> redis.Redis:
     return redis_client
 
 
-def user_hash(client: CourtListener) -> str:
-    """Derive an opaque per-user key prefix from the client's credential.
+def hmac_hex(value: str) -> str:
+    return hmac.new(
+        MCP_SECRET_BYTES, value.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
 
-    HMAC-SHA256 with MCP_SECRET_KEY so raw tokens can't be recovered from
-    Redis keys, even by someone with read access to the store. Uses the
-    OAuth ``access_token`` when present, otherwise the legacy ``api_token``.
 
-    Known limitation: OAuth access tokens rotate, so session state
-    (pagination, citation analysis jobs) will appear to belong to a
-    different user after a refresh and be orphaned until the TTL
-    expires. Tracked separately; a stable user identifier would be a
-    cleaner key.
+def token_cache_key(token: str) -> str:
+    """Redis key for the token→user_hash mapping set by the verifier."""
+    return f"mcp:token_to_user:{hmac_hex(token)}"
+
+
+async def resolve_user_hash_via_userinfo(token: str) -> str | None:
+    """Return the stable user_hash for *token*, hitting userinfo on cache miss.
+
+    Called from the auth verifier (see ``UserInfoTokenVerifier``). Returns
+    ``None`` if CL rejects the token, which the verifier translates into a
+    proper HTTP 401 at the auth layer.
+
+    The cache key is ``HMAC(token)``; the cache value is ``HMAC(sub)``. The
+    token never lands in Redis in plaintext, and the namespace is derived
+    from the stable OIDC ``sub`` claim so that rotated tokens still map to
+    the same user.
     """
-    token = client.access_token or client.api_token
+    r = get_redis()
+    cache_key = token_cache_key(token)
+    cached = await r.get(cache_key)
+    if cached:
+        return cached
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.get(
+                OAUTH_USERINFO_URL,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        logger.warning("userinfo call failed: %s", exc)
+        return None
+
+    if resp.status_code != 200:
+        # 401 from userinfo == revoked/expired/invalid. Don't cache.
+        return None
+
+    sub = resp.json().get("sub")
+    if not sub:
+        logger.warning("userinfo response missing `sub` claim")
+        return None
+
+    uh = hmac_hex(str(sub))
+    await r.set(cache_key, uh, ex=TOKEN_CACHE_TTL_SECONDS)
+    return uh
+
+
+async def invalidate_token_cache(token: str) -> None:
+    """Drop a token→user_hash mapping.
+
+    Called when CL rejects a token mid-cache (e.g. 401 on a downstream
+    API call). The *next* MCP request for this token will miss the cache,
+    re-hit userinfo, fail, and cause a proper HTTP 401 from the auth layer
+    so the MCP client re-runs OAuth.
+    """
+    try:
+        await get_redis().delete(token_cache_key(token))
+    except Exception as exc:
+        logger.warning("failed to invalidate token cache: %s", exc)
+
+
+def user_hash(client: CourtListener) -> str:
+    """Return the stable per-user key prefix for the current request.
+
+    OAuth path: reads ``user_hash`` from the FastMCP access-token claims,
+    which ``UserInfoTokenVerifier`` populated from the OIDC ``sub`` at
+    verification time. The hash survives access-token rotation because it
+    is derived from ``sub``, not the raw token.
+
+    Legacy path: hashes the API token directly, matching the old behavior
+    for non-OAuth requests.
+    """
+    try:
+        access_token = get_access_token()
+    except RuntimeError:
+        access_token = None
+
+    if access_token is not None:
+        uh = access_token.claims.get("user_hash")
+        if uh:
+            return uh
+        # Should not happen: UserInfoTokenVerifier always sets this. If
+        # another verifier is in use, fall through to token-based hashing.
+
+    token = client.api_token or client.access_token
     if not token:
         raise ValueError("Client has no credential; cannot derive user hash.")
-    return hmac.new(
-        MCP_SECRET_BYTES, token.encode("utf-8"), hashlib.sha256
-    ).hexdigest()
+    return hmac_hex(token)
 
 
 def redis_key(client: CourtListener, suffix: str) -> str:

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -22,6 +22,16 @@ MAX_NUM_RESULTS = 100
 # Session-scoped keys live in Redis for this long before being evicted.
 SESSION_TTL_SECONDS = 3600
 
+REDIS_URL = os.getenv("REDIS_URL")
+
+GIT_SHA = os.getenv("GIT_SHA", "unknown")
+
+MCP_BASE_URL = os.getenv("MCP_BASE_URL", "https://mcp.courtlistener.com")
+
+OAUTH_ISSUER = os.getenv(
+    "COURTLISTENER_OAUTH_ISSUER", "https://www.courtlistener.com"
+)
+
 MCP_SECRET_KEY = os.getenv("MCP_SECRET_KEY")
 if not MCP_SECRET_KEY:
     MCP_SECRET_KEY = "insecure-do-not-use-in-production"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 [project.optional-dependencies]
 mcp = [
     "eyecite>=2.6.0",
-    "fastmcp>=3.0.0",
+    "fastmcp>=3.2.4",
     "gunicorn>=25.3.0",
     "redis>=5.0.0",
     "tiktoken>=0.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ mcp = [
 requires-dist = [
     { name = "click", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "eyecite", marker = "extra == 'mcp'", specifier = ">=2.6.0" },
-    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0.0" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.2.4" },
     { name = "gunicorn", marker = "extra == 'mcp'", specifier = ">=25.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary

Replaces the pass-through OAuth verifier with one backed by CL's `/o/userinfo/` endpoint, keyed by a Redis cache of `hash(token) → hash(sub)`. Solves two problems at once:

- **Revoked/invalid tokens now produce proper HTTP 401s** from the MCP auth layer with `WWW-Authenticate`, so MCP clients re-run OAuth automatically. Previously CL rejection only surfaced as a tool-level error inside a 200 response, and clients never re-auth'd.
- **Session state in Redis survives access-token rotation.** Namespace prefixes are now derived from the OIDC `sub` claim (a stable per-user id) rather than the raw access token, so a refresh no longer orphans pagination state or in-flight citation analysis jobs.

Mid-cache revocation is covered by a 401-translation step in `ToolHandlerMiddleware`: when CL rejects a downstream API call, we evict the cached token mapping so the next MCP request falls through to userinfo, fails, and gets a clean 401.

Closes #112
Closes #133

## Design notes

- **Cache TTL:** 10 min default (`MCP_TOKEN_CACHE_TTL`, seconds). Longer reduces userinfo load; shorter tightens the revocation-lag window. Downstream 401 translation is the safety net for mid-cache revocation either way.
- **Scopes:** `openid` + `api` are declared `required_scopes` on the verifier so they propagate into the protected-resource metadata and MCP clients request both during authorization. `openid` is validated by userinfo itself; `api` is enforced downstream by CL's REST API.
- **Existing users:** tokens currently cached by MCP clients only carry `api`. On first use against the new server, userinfo will 401 that token → MCP 401s → well-behaved clients re-run OAuth with the new scope set. Long-tail clients may need a manual credentials reset.
- **Privacy:** neither raw tokens nor raw user IDs hit Redis — both are HMAC-SHA256'd with `MCP_SECRET_KEY`.

## Commit layout

- `build(deps)`: bump fastmcp to `>=3.2.4` for the auth APIs used here
- `refactor(mcp)`: consolidate env config into `tools/utils.py`
- `feat(mcp)`: userinfo verifier + stable user hash + 401 translation

## Assumptions worth confirming on CL's side

- [ ] OIDC is enabled in CL's `OAUTH2_PROVIDER` settings and `/o/userinfo/` is reachable in prod.
- [ ] DCR-registered public clients are permitted to request both `openid` and `api` scopes.
- [ ] The `sub` claim returned by userinfo is stable per user (default: `str(user.pk)`).

## Test plan

- [ ] Fresh OAuth flow against prod CL: authorize URL includes `scope=openid+api`, tool calls succeed.
- [ ] Simulate token rotation (clear MCP client's access token but keep refresh token) — refreshed token produces the same `user_hash`; in-flight `query_id` / `citation_job_id` resources remain addressable.
- [ ] Revoke a token in CL's admin mid-session — next tool call returns a tool error referring to re-auth, the request after that triggers an HTTP 401 and the client re-runs OAuth.
- [ ] Existing pre-change cached token (api-only scope) connects to the new server — observe the 401 → re-auth path end to end.
- [ ] Verify `/.well-known/oauth-protected-resource` advertises `scopes_supported: ["openid", "api"]`.