### PR TITLE
test(mcp): fix auth tests + changelog for userinfo verifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Changes:
 - Add CI workflow and Makefile for building and deploying the MCP server.
 - Force use of single worker per pod in production.
 - Switch MCP server to stateless HTTP. Session-scoped tool state (query pagination, citation analysis jobs) is now stored in Redis under per-user keys derived from an HMAC of the API token, so any worker can serve any request. Adds `MCP_SECRET_KEY` for the HMAC key.
+- Verify MCP OAuth tokens against CourtListener's OIDC userinfo endpoint instead of passing them through unchecked, and namespace Redis session state by a stable hash of the resolved `sub` claim rather than the raw access token. Pagination and citation-analysis state now survive access-token rotation, and revoked or invalid tokens produce a proper HTTP 401 with `WWW-Authenticate` so MCP clients re-run OAuth automatically. Downstream 401s from the CourtListener REST API evict the token cache so the next request surfaces the same re-auth signal. Requires the `openid` and `api` scopes, advertised in the protected-resource metadata; adds `MCP_TOKEN_CACHE_TTL` (seconds, default 600) and `COURTLISTENER_OAUTH_USERINFO_URL` for overriding the userinfo endpoint.
 
 Fixes:
 - Fix JSON serialization of dates and datetimes in MCP tools.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -160,10 +160,10 @@ class TestServerAuthWiring:
 
     def test_build_auth_returns_verifier_when_set(self):
         """OAuth on → returns a RemoteAuthProvider that publishes the
-        RFC 9728 protected-resource metadata, wrapping the pass-through
-        verifier. Token validation itself is delegated downstream to
-        CL's OAuth2Authentication when the tool code forwards the
-        bearer to the CourtListener API.
+        RFC 9728 protected-resource metadata, wrapping the userinfo
+        verifier. Tokens are now validated via CL's OIDC userinfo
+        endpoint, and the resolved user_hash is cached in Redis so
+        session state survives access-token rotation.
         """
         from fastmcp.server.auth.auth import RemoteAuthProvider
 
@@ -181,10 +181,12 @@ class TestServerAuthWiring:
             import importlib
 
             import courtlistener.mcp.server as server_mod
+            import courtlistener.mcp.tools.utils as utils_mod
 
+            importlib.reload(utils_mod)
             importlib.reload(server_mod)
             auth = server_mod.build_auth()
-            verifier_cls = server_mod.PassThroughTokenVerifier
+            verifier_cls = server_mod.UserInfoTokenVerifier
         assert isinstance(auth, RemoteAuthProvider)
         assert isinstance(auth.token_verifier, verifier_cls)
         # Discovery route is advertised so clients can find the auth
@@ -194,32 +196,66 @@ class TestServerAuthWiring:
         paths = {getattr(r, "path", None) for r in routes}
         assert "/.well-known/oauth-protected-resource" in paths
 
-    def test_pass_through_verifier_accepts_any_non_empty_token(self):
-        """Non-empty bearer tokens are accepted without local checks;
-        CL is the authoritative validator downstream.
+    def test_userinfo_verifier_declares_openid_and_api_scopes(self):
+        """Required scopes must appear on the verifier so they're
+        advertised in protected-resource metadata and MCP clients
+        include them in the authorize request. ``openid`` is what
+        makes userinfo accept the token at all; ``api`` is what CL's
+        REST API expects downstream.
+        """
+        from courtlistener.mcp.server import UserInfoTokenVerifier
+
+        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
+        assert set(verifier.required_scopes) == {"openid", "api"}
+
+    def test_userinfo_verifier_accepts_when_userinfo_succeeds(self):
+        """Successful userinfo lookup → AccessToken carrying the
+        resolved ``user_hash`` in its claims, plus the required scopes
+        echoed back so the middleware's scope check passes.
         """
         import asyncio
 
-        from courtlistener.mcp.server import PassThroughTokenVerifier
+        from courtlistener.mcp.server import UserInfoTokenVerifier
 
-        verifier = PassThroughTokenVerifier(
-            base_url="https://mcp.example.test"
-        )
-        token = asyncio.run(verifier.verify_token("anything-goes"))
+        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
+        with patch(
+            "courtlistener.mcp.server.resolve_user_hash_via_userinfo",
+            new=AsyncMock(return_value="fake-user-hash"),
+        ):
+            token = asyncio.run(verifier.verify_token("anything-goes"))
         assert token is not None
         assert token.token == "anything-goes"
+        assert token.claims.get("user_hash") == "fake-user-hash"
+        assert set(token.scopes) == {"openid", "api"}
 
-    def test_pass_through_verifier_rejects_empty_token(self):
-        """Empty bearer → not authenticated. Prevents trivially-empty
-        ``Authorization: Bearer`` headers from slipping through.
+    def test_userinfo_verifier_rejects_when_userinfo_fails(self):
+        """Userinfo returning ``None`` (401/non-200/network error) →
+        ``verify_token`` returns ``None``, which the auth middleware
+        converts into a proper HTTP 401 with ``WWW-Authenticate`` so
+        the MCP client re-runs OAuth.
         """
         import asyncio
 
-        from courtlistener.mcp.server import PassThroughTokenVerifier
+        from courtlistener.mcp.server import UserInfoTokenVerifier
 
-        verifier = PassThroughTokenVerifier(
-            base_url="https://mcp.example.test"
-        )
+        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
+        with patch(
+            "courtlistener.mcp.server.resolve_user_hash_via_userinfo",
+            new=AsyncMock(return_value=None),
+        ):
+            token = asyncio.run(verifier.verify_token("revoked-or-bad"))
+        assert token is None
+
+    def test_userinfo_verifier_rejects_empty_token(self):
+        """Empty bearer → short-circuit without calling userinfo.
+        Prevents trivially-empty ``Authorization: Bearer`` headers from
+        consuming a round-trip to CL.
+        """
+        import asyncio
+
+        from courtlistener.mcp.server import UserInfoTokenVerifier
+
+        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
         assert asyncio.run(verifier.verify_token("")) is None
 
     def test_build_auth_accepts_true_case_insensitively(self):
@@ -254,6 +290,60 @@ class TestServerAuthWiring:
         # depending on version); both should be falsy here.
         auth = getattr(mcp, "auth", None) or getattr(mcp, "_auth", None)
         assert not auth
+
+
+class TestUserHash:
+    """``user_hash`` picks between OAuth claims (new, stable across token
+    rotation) and a direct HMAC of the legacy API token (old behavior).
+    """
+
+    def test_reads_claim_from_oauth_context(self):
+        """With a FastMCP access token in scope carrying a ``user_hash``
+        claim (populated by ``UserInfoTokenVerifier``), ``user_hash``
+        returns the claim verbatim. Rotating the access token doesn't
+        change the hash because the claim is derived from the stable
+        OIDC ``sub``.
+        """
+        from courtlistener.mcp.tools.utils import user_hash
+
+        client = CourtListener(access_token="any-token")
+        fake_token = MagicMock()
+        fake_token.claims = {"user_hash": "claim-derived-hash"}
+        with patch(
+            "courtlistener.mcp.tools.utils.get_access_token",
+            return_value=fake_token,
+        ):
+            assert user_hash(client) == "claim-derived-hash"
+
+    def test_falls_back_to_api_token_hmac_outside_oauth_context(self):
+        """Legacy / stdio path: no FastMCP context → HMAC the API token
+        directly, matching pre-OAuth behavior.
+        """
+        from courtlistener.mcp.tools.utils import hmac_hex, user_hash
+
+        client = CourtListener(api_token="legacy-token")
+        with patch(
+            "courtlistener.mcp.tools.utils.get_access_token",
+            side_effect=RuntimeError("no HTTP request"),
+        ):
+            assert user_hash(client) == hmac_hex("legacy-token")
+
+    def test_raises_when_client_has_no_credential(self):
+        """Defensive: a client with neither an access token nor an API
+        token should never reach the Redis layer."""
+        from courtlistener.mcp.tools.utils import user_hash
+
+        client = CourtListener.__new__(CourtListener)
+        client.api_token = None
+        client.access_token = None
+        with (
+            patch(
+                "courtlistener.mcp.tools.utils.get_access_token",
+                side_effect=RuntimeError("no HTTP request"),
+            ),
+            pytest.raises(ValueError, match="no credential"),
+        ):
+            user_hash(client)
 
 
 class TestHealthEndpoint:


### PR DESCRIPTION
Follow-up to #138 — that PR replaced `PassThroughTokenVerifier` with `UserInfoTokenVerifier` but landed before the test suite and changelog were updated.

## Changes

- **tests/test_auth.py**: `TestServerAuthWiring` now exercises the userinfo verifier instead of the removed pass-through one. Userinfo responses are mocked with `AsyncMock` to keep the tests hermetic. Added `TestUserHash` covering both the new OAuth-claim path and the legacy API-token fallback.
- **CHANGES.md**: added an entry under Upcoming > Changes describing the userinfo verifier, the stable-`sub` Redis namespace, the downstream 401 handling, and the two new env vars (`MCP_TOKEN_CACHE_TTL`, `COURTLISTENER_OAUTH_USERINFO_URL`).

## Test plan

- [x] `pytest tests/` — 89 passed, 126 skipped
- [x] `pytest tests/test_auth.py -v` — 22 passed (previously 11; three failing, 8 new)