### PR TITLE
feat(mcp): serve HTML landing page at GET / for favicon discovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 The following changes are not yet released, but are code complete:
 
 Features:
-- Serve MCP server icons (favicon at small sizes, full logo at larger sizes) via the FastMCP `icons` metadata, and expose `/favicon.svg` and `/favicon.ico` routes so Google's favicon service can pick up the logo for the directory listing.
+- Serve MCP server icons (favicon at small sizes, full logo at larger sizes) via the FastMCP `icons` metadata, and expose `/favicon.svg` and `/favicon.ico` routes so Google's favicon service can pick up the logo for the directory listing. Also serve a minimal HTML landing page at `GET /` (the MCP transport itself only handles `POST`/`DELETE`, so methods don't collide) — this gives Googlebot something crawlable and includes explicit `<link rel="icon">` tags pointing at the favicon, which is what Google's favicon cache actually keys off.
 - Enable CORS on the HTTP MCP app with `Access-Control-Allow-Origin: *` and the MCP-specific headers (`mcp-protocol-version`, `mcp-session-id`, `Authorization`, `Content-Type`), so browser-based MCP clients (Inspector, Claude.ai OAuth discovery) can complete preflight and send authenticated requests.
 - Extract API token from Authorization header for HTTP MCP server.
 - Add tool annotation hints to MCP tools.

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -14,7 +14,7 @@ from mcp.types import Icon
 from pydantic import AnyHttpUrl
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
-from starlette.responses import FileResponse, JSONResponse
+from starlette.responses import FileResponse, HTMLResponse, JSONResponse
 
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
 from courtlistener.mcp.tools.utils import (
@@ -25,6 +25,35 @@ from courtlistener.mcp.tools.utils import (
     REDIS_URL,
     resolve_user_hash_via_userinfo,
 )
+
+
+INDEX_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CourtListener MCP Server</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/x-icon" href="/favicon.ico">
+<meta name="description" content="MCP (Model Context Protocol) server for the CourtListener legal research API.">
+<style>
+body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; line-height: 1.5; color: #222; }
+a { color: #b53c2c; }
+code { background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>CourtListener MCP Server</h1>
+<p>This is the HTTP endpoint for the CourtListener
+<a href="https://modelcontextprotocol.io/">Model Context Protocol</a> server,
+which exposes the <a href="https://courtlistener.com">CourtListener</a> legal
+research API to MCP-compatible clients.</p>
+<p>The MCP transport is served at <code>POST /</code>. This page exists so the
+domain is crawlable and browser visits get something useful.</p>
+<p>See the <a href="https://github.com/freelawproject/courtlistener-api-client">project repository</a> for setup instructions.</p>
+</body>
+</html>
+"""
 
 
 class UserInfoTokenVerifier(TokenVerifier):
@@ -139,6 +168,14 @@ def create_mcp_server(**kwargs):
     @mcp.custom_route("/favicon.ico", methods=["GET"])
     async def favicon_ico(request):
         return FileResponse(favicon_ico_path, media_type="image/x-icon")
+
+    # GET / serves a minimal HTML landing page so the domain is crawlable
+    # and Google's favicon service has a page to discover the favicon from.
+    # The MCP transport itself only handles POST/DELETE on /, so the methods
+    # don't collide.
+    @mcp.custom_route("/", methods=["GET"])
+    async def index(request):
+        return HTMLResponse(INDEX_HTML)
 
     @mcp.custom_route("/health", methods=["GET"])
     async def health_check(request):

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -26,7 +26,6 @@ from courtlistener.mcp.tools.utils import (
     resolve_user_hash_via_userinfo,
 )
 
-
 INDEX_HTML = """<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -168,10 +168,7 @@ def create_mcp_server(**kwargs):
     async def favicon_ico(request):
         return FileResponse(favicon_ico_path, media_type="image/x-icon")
 
-    # GET / serves a minimal HTML landing page so the domain is crawlable
-    # and Google's favicon service has a page to discover the favicon from.
-    # The MCP transport itself only handles POST/DELETE on /, so the methods
-    # don't collide.
+    # GET / serves HTML; the MCP transport owns POST/DELETE on the same path.
     @mcp.custom_route("/", methods=["GET"])
     async def index(request):
         return HTMLResponse(INDEX_HTML)

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -47,8 +47,6 @@ code { background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
 <a href="https://modelcontextprotocol.io/">Model Context Protocol</a> server,
 which exposes the <a href="https://courtlistener.com">CourtListener</a> legal
 research API to MCP-compatible clients.</p>
-<p>The MCP transport is served at <code>POST /</code>. This page exists so the
-domain is crawlable and browser visits get something useful.</p>
 <p>See the <a href="https://github.com/freelawproject/courtlistener-api-client">project repository</a> for setup instructions.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Google's S2 favicon service (`https://www.google.com/s2/favicons?domain=mcp.courtlistener.com&sz=64`) returns the empty-globe placeholder for `mcp.courtlistener.com`. The cause isn't the favicon files — those are wired up correctly by #143 — it's that the homepage isn't crawlable, so Google has no entry for the domain in its favicon index.

The MCP transport mounts at `path="/"` with `stateless_http=True`, which (per `fastmcp/server/http.py:325-336`) restricts the `/` route to `POST`/`DELETE`. A `GET /` from Googlebot returns `405 Method Not Allowed`, no HTML is parsed, the domain doesn't enter Google's index, and S2 has nothing to return.

This PR adds a minimal HTML landing page on a custom `GET /` route with explicit `<link rel="icon">` tags pointing at the existing `/favicon.svg` and `/favicon.ico` routes. Starlette dispatches by method so the new route coexists with the MCP transport (which still owns `POST`/`DELETE`).

Verified locally:

```
GET  /            → 200 text/html (with <link rel="icon"> tags)
POST /            → 200 text/event-stream (MCP initialize round-trips successfully)
GET  /favicon.ico → 200 image/x-icon
GET  /favicon.svg → 200 image/svg+xml
```

## Test plan

- [x] `pytest tests/test_auth.py` — 22 passed (the unrelated `test_tool_annotations.py` failures pre-exist and are network-only, due to tiktoken downloading its BPE encoding at test time)
- [ ] After deploy: `curl -I https://mcp.courtlistener.com/` returns 200 with `content-type: text/html`
- [ ] After deploy: `curl https://mcp.courtlistener.com/` HTML body contains `<link rel="icon" ... href="/favicon.svg">`
- [ ] After deploy: existing MCP clients still work (`POST /` end-to-end)
- [ ] Wait for Googlebot to recrawl, then re-check `https://www.google.com/s2/favicons?domain=mcp.courtlistener.com&sz=64`. (S2's cache for the prior empty result may persist for a while; that's expected.)

https://claude.ai/code/session_01UskzGX2vRH8DdfDcuSzE3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01UskzGX2vRH8DdfDcuSzE3t)_