### PR TITLE
feat(mcp): add global instructions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Changes:
 - Switch MCP server to stateless HTTP. Session-scoped tool state (query pagination, citation analysis jobs) is now stored in Redis under per-user keys derived from an HMAC of the API token, so any worker can serve any request. Adds `MCP_SECRET_KEY` for the HMAC key.
 - Verify MCP OAuth tokens against CourtListener's OIDC userinfo endpoint instead of passing them through unchecked, and namespace Redis session state by a stable hash of the resolved `sub` claim rather than the raw access token. Pagination and citation-analysis state now survive access-token rotation, and revoked or invalid tokens produce a proper HTTP 401 with `WWW-Authenticate` so MCP clients re-run OAuth automatically. Downstream 401s from the CourtListener REST API evict the token cache so the next request surfaces the same re-auth signal. Requires the `openid` and `api` scopes, advertised in the protected-resource metadata; adds `MCP_TOKEN_CACHE_TTL` (seconds, default 600) and `COURTLISTENER_OAUTH_USERINFO_URL` for overriding the userinfo endpoint.
 - Point index html to the Free Law wiki for MCP setup instructions.
+- Add MCP server instructions to the global prompt.
 
 Fixes:
 - Fix JSON serialization of dates and datetimes in MCP tools.

--- a/courtlistener/mcp/prompts.py
+++ b/courtlistener/mcp/prompts.py
@@ -7,7 +7,7 @@ The `search` tool covers four primary collections:
 - RECAP (federal court cases/dockets, filings, parties, and attorneys from PACER)
 - Opinions (case law / court decisions)
 - Judges (their financial disclosures are not searchable, but are available via the regular API)
-- Oral arguments (audio recordings of appellate arguments)
+- Oral arguments (audio recordings and transcripts of appellate arguments)
 
 For richer detail on individual objects (opinions, dockets, parties, clusters,
 courts, etc.) use `get_endpoint_schema` to discover the available REST

--- a/courtlistener/mcp/prompts.py
+++ b/courtlistener/mcp/prompts.py
@@ -6,7 +6,7 @@ CourtListener MCP server: access to the CourtListener legal research API.
 The `search` tool covers four primary collections:
 - RECAP (federal court cases/dockets, filings, parties, and attorneys from PACER)
 - Opinions (case law / court decisions)
-- Judges
+- Judges (their financial disclosures are not searchable, but are available via the regular API)
 - Oral arguments (audio recordings of appellate arguments)
 
 For richer detail on individual objects (opinions, dockets, parties, clusters,

--- a/courtlistener/mcp/prompts.py
+++ b/courtlistener/mcp/prompts.py
@@ -1,0 +1,43 @@
+GLOBAL_INSTRUCTIONS = """\
+CourtListener MCP server: access to the CourtListener legal research API.
+
+# Data available
+
+The `search` tool covers four primary collections:
+- RECAP (federal court filings and dockets from PACER)
+- Opinions (case law / court decisions)
+- Judges
+- Oral arguments (audio recordings of appellate arguments)
+
+For richer detail on individual objects (opinions, dockets, parties, clusters,
+courts, etc.) use `get_endpoint_schema` to discover the available REST
+endpoint schemas, then `call_endpoint` to fetch from them. These endpoints expose
+fields and relationships that the search index does not.
+
+# Use the `fields` argument
+
+Both `search` and `call_endpoint` accept a `fields` argument that restricts
+the response payload to the fields you name. CourtListener responses can be
+very large; using `fields` aggressively reduces token usage and latency.
+Default to requesting only the fields you actually need.
+
+# Opinion text fields
+
+Opinion records carry the full opinion text in several fields, which can be
+enormous. Exclude these unless you need the document text. When you do need
+the text, prefer the `html_with_citations` field — it consolidates the best
+available source (often replacing raw `plain_text`, `html`, `html_lawbox`,
+etc.) and includes inline citation markup.
+
+# Linking to dockets and opinions
+
+Docket and opinion URLs on courtlistener.com require *something* after the
+ID (normally a case-name slug). Without it, the link 404s. When you don't
+have a slug, repeat the resource name as the trailing segment:
+
+    https://www.courtlistener.com/docket/{docket_id}/docket/
+    https://www.courtlistener.com/opinion/{opinion_id}/opinion/
+
+This is the safest format — it always resolves correctly even though it
+looks redundant.
+"""

--- a/courtlistener/mcp/prompts.py
+++ b/courtlistener/mcp/prompts.py
@@ -4,7 +4,7 @@ CourtListener MCP server: access to the CourtListener legal research API.
 # Data available
 
 The `search` tool covers four primary collections:
-- RECAP (federal court filings and dockets from PACER)
+- RECAP (federal court cases/dockets, filings, parties, and attorneys from PACER)
 - Opinions (case law / court decisions)
 - Judges
 - Oral arguments (audio recordings of appellate arguments)

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -20,6 +20,7 @@ from starlette.responses import (
 
 from courtlistener.mcp.auth import UserInfoTokenVerifier
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
+from courtlistener.mcp.prompts import GLOBAL_INSTRUCTIONS
 from courtlistener.mcp.tools.utils import (
     BASE_DIR,
     GIT_SHA,
@@ -73,6 +74,7 @@ def create_mcp_server(**kwargs):
 
     mcp = FastMCP(
         name="CourtListener",
+        instructions=GLOBAL_INSTRUCTIONS,
         website_url="https://courtlistener.com",
         icons=[
             Icon(


### PR DESCRIPTION
Fixes #142

Added instructions to communicate the following:

* A general sense of the data available. How the search endpoints cover recap data, opinions, judges, and oral arguments. But also explain that the additional endpoints (exposed by the get_endpoint_schema and call_endpoint tools can be used to access more detailed information for key objects like opinions, dockets, etc.)
* When linking to dockets, use the following format https://www.courtlistener.com/docket/{docket_id}/docket/ The model often provides these links without the trailing /docket which doesnt work. The truth is that these links just need *something* after the end (on courtlistener these are provided with slugs for the case name). But since this is hard to infer, we should just tell models to use something generic like "/docket" so the links work.
* Encourage the models to use the fields argument for both the search tool and call endpoints tool. This can dramatically reduce the tokens of otherwise potentially explosive responses.
* For the opinions endpoint in particular, the text fields can consume a ton of tokens as they return the full opinion text. Exclude these fields when not needed. If you do want the document text, html_with_citations is the preferred field that consolidates from other sources.