### PR TITLE
Add wait to analyze citations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Changes:
 - Verify MCP OAuth tokens against CourtListener's OIDC userinfo endpoint instead of passing them through unchecked, and namespace Redis session state by a stable hash of the resolved `sub` claim rather than the raw access token. Pagination and citation-analysis state now survive access-token rotation, and revoked or invalid tokens produce a proper HTTP 401 with `WWW-Authenticate` so MCP clients re-run OAuth automatically. Downstream 401s from the CourtListener REST API evict the token cache so the next request surfaces the same re-auth signal. Requires the `openid` and `api` scopes, advertised in the protected-resource metadata; adds `MCP_TOKEN_CACHE_TTL` (seconds, default 600) and `COURTLISTENER_OAUTH_USERINFO_URL` for overriding the userinfo endpoint.
 - Point index html to the Free Law wiki for MCP setup instructions.
 - Add MCP server instructions to the global prompt.
+- Add `retry_on_rate_limit` parameter to `citation_lookup` helper for retrying on 429s.
 
 Fixes:
 - Fix JSON serialization of dates and datetimes in MCP tools.

--- a/courtlistener/citation_lookup.py
+++ b/courtlistener/citation_lookup.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import time
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
+
+from courtlistener.exceptions import CourtListenerAPIError
 
 if TYPE_CHECKING:
     from courtlistener.client import CourtListener
 
 MAX_TEXT_LENGTH = 64_000
 THROTTLE_STATUS = 429
+MAX_RETRY_WAIT_SECONDS = 90.0
 
 
 class CitationLookup:
@@ -23,7 +28,12 @@ class CitationLookup:
     def __init__(self, client: CourtListener) -> None:
         self._client = client
 
-    def lookup_text(self, text: str) -> list[dict[str, Any]]:
+    def lookup_text(
+        self,
+        text: str,
+        *,
+        retry_on_rate_limit: bool = False,
+    ) -> list[dict[str, Any]]:
         """Look up all citations in a block of text.
 
         Sends text to CourtListener's citation-lookup endpoint, which
@@ -32,6 +42,11 @@ class CitationLookup:
 
         Args:
             text: Legal text containing citations (max 64,000 chars).
+            retry_on_rate_limit: If True, a whole-request 429 response
+                triggers a single retry after sleeping until the
+                ``wait_until`` timestamp in the error body (capped at
+                ``MAX_RETRY_WAIT_SECONDS``). If the second attempt also
+                429s, the error is raised.
 
         Returns:
             List of citation results. Each result contains:
@@ -45,15 +60,28 @@ class CitationLookup:
 
         Raises:
             ValueError: If text exceeds 64,000 characters.
+            CourtListenerAPIError: On API errors (including 429 when
+                retry is disabled or the retry also fails).
         """
         if len(text) > MAX_TEXT_LENGTH:
             raise ValueError(
                 f"Text length {len(text)} exceeds the maximum of "
                 f"{MAX_TEXT_LENGTH} characters."
             )
-        result = self._client._request(
-            "POST", self.ENDPOINT, data={"text": text}
-        )
+        try:
+            result = self._client._request(
+                "POST", self.ENDPOINT, data={"text": text}
+            )
+        except CourtListenerAPIError as e:
+            if not retry_on_rate_limit or e.status_code != THROTTLE_STATUS:
+                raise
+            wait = _wait_until_seconds(e.detail)
+            if wait is None:
+                raise
+            time.sleep(wait)
+            result = self._client._request(
+                "POST", self.ENDPOINT, data={"text": text}
+            )
         assert isinstance(result, list)
         return result
 
@@ -151,6 +179,36 @@ class CitationLookup:
             remaining = remaining[first_throttled_start:]
 
         return all_results
+
+
+def parse_wait_until(detail: Any) -> datetime | None:
+    """Parse the ``wait_until`` timestamp from a 429 error body.
+
+    Returns a timezone-aware datetime, or None if the body shape is
+    unexpected or the value can't be parsed. Naive timestamps are
+    interpreted as UTC.
+    """
+    if not isinstance(detail, dict):
+        return None
+    wait_until = detail.get("wait_until")
+    if not isinstance(wait_until, str):
+        return None
+    try:
+        target = datetime.fromisoformat(wait_until)
+    except ValueError:
+        return None
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=timezone.utc)
+    return target
+
+
+def _wait_until_seconds(detail: Any) -> float | None:
+    """Seconds to sleep before retrying a 429, clamped to the cap, or None."""
+    target = parse_wait_until(detail)
+    if target is None:
+        return None
+    seconds = (target - datetime.now(timezone.utc)).total_seconds()
+    return max(0.0, min(seconds, MAX_RETRY_WAIT_SECONDS))
 
 
 def _split_text(text: str) -> list[tuple[int, str]]:

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+from typing import Any
+
 from eyecite import get_citations, resolve_citations
 from eyecite.models import FullCaseCitation
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.citation_utils import (
     MAX_CITATIONS_PER_REQUEST,
     build_compact_string,
     canonical_key,
     citation_type_label,
     format_analysis,
+    format_rate_limit_note,
     input_case_name,
     process_api_results,
 )
@@ -163,11 +167,18 @@ class AnalyzeCitationsTool(MCPTool):
 
             pending = list(sendable)
 
+            rate_limit_detail: Any = None
             if sendable:
                 batch = pending[:MAX_CITATIONS_PER_REQUEST]
                 compact_text = build_compact_string(batch)
-                results = client.citation_lookup.lookup_text(compact_text)
-                process_api_results(results, batch, verified, pending)
+                try:
+                    results = client.citation_lookup.lookup_text(compact_text)
+                except CourtListenerAPIError as e:
+                    if e.status_code != 429:
+                        raise
+                    rate_limit_detail = e.detail
+                else:
+                    process_api_results(results, batch, verified, pending)
 
             # Step 4: Store in user-scoped session store
             analysis_id = make_id()
@@ -194,4 +205,9 @@ class AnalyzeCitationsTool(MCPTool):
                 pending,
                 input_case_names,
             )
+            if rate_limit_detail is not None:
+                output += "\n\n" + format_rate_limit_note(
+                    rate_limit_detail,
+                    resumable_with="resume_citation_analysis",
+                )
             return output

--- a/courtlistener/mcp/tools/citation_utils.py
+++ b/courtlistener/mcp/tools/citation_utils.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime, timezone
 from difflib import SequenceMatcher
 from typing import Any
+
+from courtlistener.citation_lookup import parse_wait_until
 
 from eyecite.models import (
     CitationBase,
@@ -175,6 +178,54 @@ def canonical_key(cite: FullCitation) -> str:
     return f"{g['volume']} {g['reporter']} {g['page']}"
 
 
+def format_rate_limit_note(detail: Any, *, resumable_with: str) -> str:
+    """Build a one-line note describing the upstream rate limit.
+
+    Always returns a usable message — when ``wait_until`` can't be
+    parsed, falls back to advice without a timestamp. ``resumable_with``
+    names the tool to call next (e.g. ``resume_citation_analysis``).
+    """
+    target = parse_wait_until(detail)
+    base = (
+        f"Rate limited by the upstream API. Call `{resumable_with}` to "
+        f"retry; set `wait=true` to have the server sleep through the "
+        f"rate-limit window."
+    )
+    if target is None:
+        return base
+    seconds = max(0, int((target - datetime.now(timezone.utc)).total_seconds()))
+    return (
+        f"Rate limited by the upstream API (retry in ~{seconds}s, "
+        f"wait_until={target.isoformat()}). Call `{resumable_with}` "
+        f"with `wait=true` to have the server sleep through the window."
+    )
+
+
+def format_unresolved_section(unresolved: list[CitationBase]) -> list[str]:
+    """Render the Unresolved section, deduped by (label, matched text).
+
+    Eyecite emits every textual occurrence of short forms (``id.``,
+    ``supra``, repeated short cites), so the raw list is noisy. Collapse
+    identical rows into one with a reference count, matching how the
+    resolved-cases section presents repeats.
+    """
+    counts: dict[tuple[str, str], int] = {}
+    order: list[tuple[str, str]] = []
+    for c in unresolved:
+        key = (citation_type_label(c), c.matched_text() or "")
+        if key not in counts:
+            order.append(key)
+        counts[key] = counts.get(key, 0) + 1
+
+    lines = ["\nUnresolved:"]
+    for i, key in enumerate(order, 1):
+        label, text = key
+        n = counts[key]
+        suffix = f" — {n} reference(s)" if n > 1 else ""
+        lines.append(f'  {i}. [{label}] "{text}"{suffix}')
+    return lines
+
+
 def format_resolved_citations(
     cites: list[CitationBase],
     resolutions: Any,
@@ -251,10 +302,7 @@ def format_resolved_citations(
                     parts.append(f'       [{label}] "{c.matched_text()}"')
 
     if unresolved:
-        parts.append("\nUnresolved:")
-        for i, c in enumerate(unresolved, 1):
-            label = citation_type_label(c)
-            parts.append(f'  {i}. [{label}] "{c.matched_text()}"')
+        parts.extend(format_unresolved_section(unresolved))
 
     return "\n".join(parts)
 
@@ -645,10 +693,7 @@ def format_analysis(
 
     # Unresolved
     if unresolved:
-        parts.append("\nUnresolved:")
-        for i, c in enumerate(unresolved, 1):
-            label = citation_type_label(c)
-            parts.append(f'  {i}. [{label}] "{c.matched_text()}"')
+        parts.extend(format_unresolved_section(unresolved))
 
     return "\n".join(parts)
 

--- a/courtlistener/mcp/tools/citation_utils.py
+++ b/courtlistener/mcp/tools/citation_utils.py
@@ -7,8 +7,6 @@ from datetime import datetime, timezone
 from difflib import SequenceMatcher
 from typing import Any
 
-from courtlistener.citation_lookup import parse_wait_until
-
 from eyecite.models import (
     CitationBase,
     FullCaseCitation,
@@ -23,6 +21,8 @@ from eyecite.models import (
     Resource as CitationResource,
 )
 from eyecite.utils import DISALLOWED_NAMES
+
+from courtlistener.citation_lookup import parse_wait_until
 
 # Delimiter used between citations in the compact string sent to the
 # citation-lookup API.  Semicolon-space is a natural Bluebook list
@@ -193,7 +193,9 @@ def format_rate_limit_note(detail: Any, *, resumable_with: str) -> str:
     )
     if target is None:
         return base
-    seconds = max(0, int((target - datetime.now(timezone.utc)).total_seconds()))
+    seconds = max(
+        0, int((target - datetime.now(timezone.utc)).total_seconds())
+    )
     return (
         f"Rate limited by the upstream API (retry in ~{seconds}s, "
         f"wait_until={target.isoformat()}). Call `{resumable_with}` "

--- a/courtlistener/mcp/tools/resume_citation_analysis_tool.py
+++ b/courtlistener/mcp/tools/resume_citation_analysis_tool.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.citation_utils import (
     MAX_CITATIONS_PER_REQUEST,
     build_compact_string,
+    format_rate_limit_note,
     format_resume,
     process_api_results,
 )
@@ -44,12 +46,25 @@ class ResumeCitationAnalysisTool(MCPTool):
                         "analyze_citations call."
                     ),
                 },
+                "wait": {
+                    "type": "boolean",
+                    "description": (
+                        "If true, the server sleeps through the upstream "
+                        "rate-limit window (capped at ~90s) and retries "
+                        "automatically. Use this after a previous call "
+                        "reported a short wait_until. Default false: the "
+                        "tool returns immediately on rate limit so you can "
+                        "tell the user before waiting."
+                    ),
+                    "default": False,
+                },
             },
             "required": ["job_id"],
         }
 
     async def __call__(self, arguments: dict, ctx: Context) -> str:
         job_id = arguments["job_id"]
+        wait = bool(arguments.get("wait", False))
         with self.get_client() as client:
             job = await get_session_citation_analysis(job_id, client)
             if job is None:
@@ -64,7 +79,21 @@ class ResumeCitationAnalysisTool(MCPTool):
             # Verify next batch
             batch = pending[:MAX_CITATIONS_PER_REQUEST]
             compact_text = build_compact_string(batch)
-            results = client.citation_lookup.lookup_text(compact_text)
+            try:
+                results = client.citation_lookup.lookup_text(
+                    compact_text, retry_on_rate_limit=wait
+                )
+            except CourtListenerAPIError as e:
+                if e.status_code != 429:
+                    raise
+                return (
+                    format_resume(job_id, job, set())
+                    + "\n\n"
+                    + format_rate_limit_note(
+                        e.detail,
+                        resumable_with="resume_citation_analysis",
+                    )
+                )
 
             previously_verified = set(job["verified"].keys())
             process_api_results(


### PR DESCRIPTION
This PR does three things:

- Adds a retry_on_rate_limit argument that waits and retries the citation lookup if a rate limit is hit. The wait is based on the wait_until field from the rate limit response (capped at 90s)
- Exposes an analogous wait argument for the resume citations tool so that the llm can decide if it wants to wait.
- Adds formatting to the rate limit response when it does surface, to avoid the complaint about raw 429 response in #119 

Also snuck in:
- A formatting helper for unresolved citations that deduplicates the unresolved list in the response (in some docs we had 100s of redundant unresolved strings).