### PR TITLE
Improve alert tool error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ Fixes:
 - Add valid search types to create search alert tool and client helper.
 - Warn in `analyze_citations` output when a verified cluster's case name diverges from the input name, clarify the "occurrences vs unique strings vs unique case clusters" counts in the header, and auto-resolve ambiguous results whose candidate clusters share the same name (surfacing the other cluster IDs).
 - Fix `analyze_citations` tool to use the `html_with_citations` field for the opinion text.
+- Gracefully error handling for alerts tools.
 
 ### 0.0.6 - 2026-03-19
 

--- a/courtlistener/alerts.py
+++ b/courtlistener/alerts.py
@@ -178,6 +178,9 @@ class DocketAlerts(Resource):
 
     def subscribe(self, docket: int) -> dict[str, Any]:
         """Subscribe to a docket (convenience for create with type=1)."""
+        for alert in self.list(docket=docket):
+            return {**alert, "already_subscribed": True}
+
         return self.create(docket, alert_type=1)
 
     def unsubscribe(self, docket: int) -> None:

--- a/courtlistener/mcp/tools/create_search_alert_tool.py
+++ b/courtlistener/mcp/tools/create_search_alert_tool.py
@@ -1,6 +1,7 @@
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 
 
@@ -58,17 +59,21 @@ class CreateSearchAlertTool(MCPTool):
             "required": ["name", "query", "rate"],
         }
 
-    async def __call__(self, arguments: dict, ctx: Context) -> dict:
+    async def __call__(self, arguments: dict, ctx: Context) -> dict | str:
         name = arguments["name"]
         query = arguments["query"]
         rate = arguments["rate"]
         alert_type = arguments.get("alert_type")
 
         with self.get_client() as client:
-            alert = client.alerts.create(
-                name=name,
-                query=query,
-                rate=rate,
-                alert_type=alert_type,
-            )
-            return alert
+            try:
+                return client.alerts.create(
+                    name=name,
+                    query=query,
+                    rate=rate,
+                    alert_type=alert_type,
+                )
+            except CourtListenerAPIError as e:
+                if e.status_code != 400:
+                    raise
+                return f"Could not create search alert: {e.detail}"

--- a/courtlistener/mcp/tools/delete_search_alert_tool.py
+++ b/courtlistener/mcp/tools/delete_search_alert_tool.py
@@ -1,6 +1,7 @@
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 
 
@@ -35,5 +36,10 @@ class DeleteSearchAlertTool(MCPTool):
         alert_id = arguments["id"]
 
         with self.get_client() as client:
-            client.alerts.delete(alert_id)
+            try:
+                client.alerts.delete(alert_id)
+            except CourtListenerAPIError as e:
+                if e.status_code == 404:
+                    return f"No alert found with id {alert_id}."
+                raise
             return f"Deleted search alert {alert_id}."

--- a/courtlistener/mcp/tools/subscribe_to_docket_alert_tool.py
+++ b/courtlistener/mcp/tools/subscribe_to_docket_alert_tool.py
@@ -1,6 +1,7 @@
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 
 
@@ -32,9 +33,13 @@ class SubscribeToDocketAlertTool(MCPTool):
             "required": ["docket"],
         }
 
-    async def __call__(self, arguments: dict, ctx: Context) -> dict:
+    async def __call__(self, arguments: dict, ctx: Context) -> dict | str:
         docket = arguments["docket"]
 
         with self.get_client() as client:
-            alert = client.docket_alerts.subscribe(docket)
-            return alert
+            try:
+                return client.docket_alerts.subscribe(docket)
+            except CourtListenerAPIError as e:
+                if e.status_code != 400:
+                    raise
+                return f"Could not subscribe to docket {docket}: {e.detail}"

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs
 
+import httpx
 import pytest
 from pydantic import ValidationError
 
@@ -11,6 +12,7 @@ from courtlistener.alerts import (
     SearchAlerts,
     normalize_search_query,
 )
+from courtlistener.exceptions import CourtListenerAPIError
 
 # ---------------------------------------------------------------------------
 # Unit tests – normalize_search_query
@@ -109,6 +111,57 @@ class TestSearchAlertsValidation:
         alerts = SearchAlerts(mock_client)
         with pytest.raises(ValidationError):
             alerts.update(1, unknown_field="value")
+
+
+def _page(results):
+    return {
+        "count": len(results),
+        "next": None,
+        "previous": None,
+        "results": results,
+    }
+
+
+class TestDocketAlertsSubscribeIdempotent:
+    """Issue #121: ``subscribe`` is idempotent at the SDK layer."""
+
+    def test_creates_when_no_existing_subscription(self):
+        mock_client = MagicMock()
+        created = {"id": 1, "docket": 5, "alert_type": 1}
+        mock_client._request.side_effect = [_page([]), created]
+
+        da = DocketAlerts(mock_client)
+        result = da.subscribe(docket=5)
+
+        assert result == created
+        assert "already_subscribed" not in result
+
+    def test_returns_existing_with_flag(self):
+        mock_client = MagicMock()
+        existing = {"id": 1, "docket": 5, "alert_type": 1}
+        mock_client._request.side_effect = [_page([existing])]
+
+        da = DocketAlerts(mock_client)
+        result = da.subscribe(docket=5)
+
+        assert result["id"] == 1
+        assert result["already_subscribed"] is True
+        # Pre-flight list only — no POST.
+        assert mock_client._request.call_count == 1
+
+    def test_create_400_still_raises(self):
+        mock_client = MagicMock()
+        other_error = CourtListenerAPIError(
+            400,
+            {"docket": ["Invalid pk."]},
+            MagicMock(spec=httpx.Response, status_code=400),
+        )
+        mock_client._request.side_effect = [_page([]), other_error]
+
+        da = DocketAlerts(mock_client)
+        with pytest.raises(CourtListenerAPIError) as exc_info:
+            da.subscribe(docket=5)
+        assert exc_info.value.status_code == 400
 
 
 class TestDocketAlertsValidation:

--- a/tests/test_mcp_mutation_errors.py
+++ b/tests/test_mcp_mutation_errors.py
@@ -1,0 +1,171 @@
+"""Friendly error translation for mutation MCP tools.
+
+Covers the regression in issue #120: ``delete_search_alert``,
+``subscribe_to_docket_alert`` and ``create_search_alert`` previously
+leaked raw ``HTTP 4xx: {...}`` strings (Django internals) to MCP
+clients. They now catch the well-defined client-error cases and
+return clean messages, while still bubbling genuine server errors.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.mcp.tools.create_search_alert_tool import (
+    CreateSearchAlertTool,
+)
+from courtlistener.mcp.tools.delete_search_alert_tool import (
+    DeleteSearchAlertTool,
+)
+from courtlistener.mcp.tools.subscribe_to_docket_alert_tool import (
+    SubscribeToDocketAlertTool,
+)
+
+
+def _api_error(status_code: int, detail) -> CourtListenerAPIError:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    return CourtListenerAPIError(status_code, detail, response)
+
+
+def _client_cm(client):
+    """Wrap a mock client in a context manager (for ``with get_client()``)."""
+    cm = MagicMock()
+    cm.__enter__.return_value = client
+    cm.__exit__.return_value = False
+    return cm
+
+
+class TestDeleteSearchAlertErrors:
+    @pytest.mark.asyncio
+    async def test_missing_id_returns_clean_message(self, monkeypatch):
+        client = MagicMock()
+        client.alerts.delete.side_effect = _api_error(
+            404, {"detail": "No Alert matches the given query."}
+        )
+        tool = DeleteSearchAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        result = await tool({"id": 99999999}, ctx=MagicMock())
+
+        assert result == "No alert found with id 99999999."
+
+    @pytest.mark.asyncio
+    async def test_server_error_still_raises(self, monkeypatch):
+        client = MagicMock()
+        client.alerts.delete.side_effect = _api_error(500, "boom")
+        tool = DeleteSearchAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        with pytest.raises(CourtListenerAPIError) as exc_info:
+            await tool({"id": 1}, ctx=MagicMock())
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_success_path_unchanged(self, monkeypatch):
+        client = MagicMock()
+        client.alerts.delete.return_value = None
+        tool = DeleteSearchAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        result = await tool({"id": 42}, ctx=MagicMock())
+
+        assert result == "Deleted search alert 42."
+
+
+class TestSubscribeToDocketAlertErrors:
+    @pytest.mark.asyncio
+    async def test_already_subscribed_dict_passes_through(self, monkeypatch):
+        """SDK now handles the unique-set 400 by returning the existing alert
+        dict with ``already_subscribed=True``. The MCP tool should forward
+        that dict unchanged (covered in SDK tests; this just locks in
+        the boundary contract).
+        """
+        existing = {
+            "id": 7,
+            "docket": 73209323,
+            "alert_type": 1,
+            "already_subscribed": True,
+        }
+        client = MagicMock()
+        client.docket_alerts.subscribe.return_value = existing
+        tool = SubscribeToDocketAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        result = await tool({"docket": 73209323}, ctx=MagicMock())
+
+        assert result == existing
+
+    @pytest.mark.asyncio
+    async def test_other_400_returns_clean_message(self, monkeypatch):
+        detail = {"docket": ["Invalid pk - object does not exist."]}
+        client = MagicMock()
+        client.docket_alerts.subscribe.side_effect = _api_error(400, detail)
+        tool = SubscribeToDocketAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        result = await tool({"docket": 1}, ctx=MagicMock())
+
+        assert isinstance(result, str)
+        assert result.startswith("Could not subscribe to docket 1:")
+        # Importantly: no "HTTP 400" prefix leak.
+        assert "HTTP 400" not in result
+
+    @pytest.mark.asyncio
+    async def test_server_error_still_raises(self, monkeypatch):
+        client = MagicMock()
+        client.docket_alerts.subscribe.side_effect = _api_error(500, "boom")
+        tool = SubscribeToDocketAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        with pytest.raises(CourtListenerAPIError) as exc_info:
+            await tool({"docket": 1}, ctx=MagicMock())
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_success_path_returns_alert_dict(self, monkeypatch):
+        alert = {"id": 1, "docket": 1, "alert_type": 1}
+        client = MagicMock()
+        client.docket_alerts.subscribe.return_value = alert
+        tool = SubscribeToDocketAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        result = await tool({"docket": 1}, ctx=MagicMock())
+
+        assert result == alert
+
+
+class TestCreateSearchAlertErrors:
+    @pytest.mark.asyncio
+    async def test_bad_request_returns_clean_message(self, monkeypatch):
+        client = MagicMock()
+        client.alerts.create.side_effect = _api_error(
+            400, {"query": ["Invalid query syntax."]}
+        )
+        tool = CreateSearchAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        result = await tool(
+            {"name": "x", "query": "q=foo", "rate": "off"},
+            ctx=MagicMock(),
+        )
+
+        assert isinstance(result, str)
+        assert result.startswith("Could not create search alert:")
+        assert "HTTP 400" not in result
+
+    @pytest.mark.asyncio
+    async def test_server_error_still_raises(self, monkeypatch):
+        client = MagicMock()
+        client.alerts.create.side_effect = _api_error(500, "boom")
+        tool = CreateSearchAlertTool()
+        monkeypatch.setattr(tool, "get_client", lambda: _client_cm(client))
+
+        with pytest.raises(CourtListenerAPIError) as exc_info:
+            await tool(
+                {"name": "x", "query": "q=foo", "rate": "off"},
+                ctx=MagicMock(),
+            )
+        assert exc_info.value.status_code == 500


### PR DESCRIPTION
Fixes #121 #120

For search alert and docket subscription tools, return informative strings when creating duplicates or deleting non-existent ids.

The docket alert subscribe method in the API client also returns "already_subscribed" hint and returns the subscription object instead of erroring is there is an attempt to make a duplicate subscription.