### PR TITLE
feat(mcp): make sentry traces sample rate configurable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Features:
 Changes:
 - Add fallback handling for HTTP errors in MCP tool handler middleware.
 - Add error message for rate limit exceeded errors.
+- Add `SENTRY_TRACES_SAMPLE_RATE` env var to control the sample rate for Sentry traces.
 
 Fixes:
 - Catch falsy `SENTRY_DSN` variable.

--- a/courtlistener/mcp/app.py
+++ b/courtlistener/mcp/app.py
@@ -8,7 +8,7 @@ from courtlistener.mcp.server import create_http_app
 sentry_sdk.init(
     dsn=os.getenv("SENTRY_DSN") or None,
     integrations=[MCPIntegration()],
-    traces_sample_rate=1.0,
+    traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE") or 0.02),
 )
 
 app = create_http_app()


### PR DESCRIPTION
Fixes #174

Set SENTRY_TRACES_SAMPLE_RATE in env to configure. Defaults to 0.02.