### PR TITLE
feat(mcp): always return dict for doc search tool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
 - Add fallback handling for HTTP errors in MCP tool handler middleware.
 - Add error message for rate limit exceeded errors.
 - Add `SENTRY_TRACES_SAMPLE_RATE` env var to control the sample rate for Sentry traces.
+- Make `search_document` tool always return a dict, even for multi-document searches.
 
 Fixes:
 - Catch falsy `SENTRY_DSN` variable.

--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -68,7 +68,7 @@ class ToolHandlerMiddleware(Middleware):
                 f"Upstream CourtListener request failed: {exc}"
             ) from exc
 
-        if isinstance(result, (dict, list)):
+        if isinstance(result, dict):
             result = json.dumps(result, default=json_default, indent=2)
         if isinstance(result, str):
             return ToolResult(

--- a/courtlistener/mcp/tools/search_document_tool.py
+++ b/courtlistener/mcp/tools/search_document_tool.py
@@ -145,7 +145,7 @@ class SearchDocumentTool(MCPTool):
             "snippets": snippets,
         }
 
-    async def __call__(self, arguments: dict, ctx: Context) -> dict | list:
+    async def __call__(self, arguments: dict, ctx: Context) -> dict:
         opinion_id = arguments.get("opinion_id")
         recap_document_id = arguments.get("recap_document_id")
 
@@ -175,4 +175,6 @@ class SearchDocumentTool(MCPTool):
                 for doc_id in doc_ids
             ]
 
-        return results if multi else results[0]
+        if multi:
+            return {"results": results}
+        return results[0]


### PR DESCRIPTION
Small tweak for consistency. Make search_document return a dict even for multi-document searches.