### PR TITLE
In memory session support and code reorg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Features:
 - Add `search_document` tool for searching for snippets within one or more court opinions or RECAP documents.
 - Add generated documentation for API endpoints and MCP tools.
 - Add mypy workflow, documentation check, and API check to CI.
+- Added in-memory session support for MCP server.
 
 Changes:
 - Add fallback handling for HTTP errors in MCP tool handler middleware.

--- a/courtlistener/mcp/app.py
+++ b/courtlistener/mcp/app.py
@@ -1,14 +1,13 @@
-import os
-
 import sentry_sdk
 from sentry_sdk.integrations.mcp import MCPIntegration
 
 from courtlistener.mcp.server import create_http_app
+from courtlistener.mcp.settings import SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE
 
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN") or None,
+    dsn=SENTRY_DSN,
     integrations=[MCPIntegration()],
-    traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE") or 0.02),
+    traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
 )
 
 app = create_http_app()

--- a/courtlistener/mcp/assets/index.html
+++ b/courtlistener/mcp/assets/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CourtListener MCP Server</title>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<meta name="google-site-verification" content="C8dEEUUkQm1uhzt8FLvr1mAKcuEOkMiTi5a0nFgs5Qw" />
+<meta name="description" content="MCP (Model Context Protocol) server for the CourtListener legal research API.">
+<style>
+body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; line-height: 1.5; color: #222; }
+a { color: #b53c2c; }
+code { background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>CourtListener MCP Server</h1>
+<p>This is the HTTP endpoint for the CourtListener Model Context Protocol server,
+which exposes the <a href="https://courtlistener.com">CourtListener</a> legal
+research API to MCP-compatible clients.</p>
+<p>See the <a href="https://wiki.free.law/c/courtlistener/help/api/mcp">MCP documentation</a> on the Free Law Wiki for setup instructions.</p>
+</body>
+</html>

--- a/courtlistener/mcp/assets/index.html
+++ b/courtlistener/mcp/assets/index.html
@@ -7,7 +7,6 @@
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-<meta name="google-site-verification" content="C8dEEUUkQm1uhzt8FLvr1mAKcuEOkMiTi5a0nFgs5Qw" />
 <meta name="description" content="MCP (Model Context Protocol) server for the CourtListener legal research API.">
 <style>
 body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; line-height: 1.5; color: #222; }

--- a/courtlistener/mcp/auth.py
+++ b/courtlistener/mcp/auth.py
@@ -1,19 +1,59 @@
+import logging
+
+import httpx
 from fastmcp.server.auth.auth import (
     AccessToken,
     TokenVerifier,
 )
 
-from courtlistener.mcp.tools.utils import resolve_user_hash_via_userinfo
+from courtlistener.mcp.session import get_session, hmac_hex
+from courtlistener.mcp.settings import (
+    OAUTH_USERINFO_URL,
+    USERINFO_TIMEOUT_SECONDS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_user_hash_via_userinfo(token: str) -> str | None:
+    """Return the stable user_hash for *token*, hitting userinfo on cache miss."""
+    session = get_session()
+    cached = await session.get_user_hash(token)
+    if cached:
+        return cached
+
+    try:
+        async with httpx.AsyncClient(timeout=USERINFO_TIMEOUT_SECONDS) as http:
+            resp = await http.get(
+                OAUTH_USERINFO_URL,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        logger.warning("userinfo call failed: %s", exc)
+        return None
+
+    if resp.status_code != 200:
+        # 401 from userinfo == revoked/expired/invalid. Don't cache.
+        return None
+
+    sub = resp.json().get("sub")
+    if not sub:
+        logger.warning("userinfo response missing `sub` claim")
+        return None
+
+    uh = hmac_hex(str(sub))
+    await session.store_user_hash(token, uh)
+    return uh
 
 
 class UserInfoTokenVerifier(TokenVerifier):
     """Verify OAuth tokens by calling CL's OIDC userinfo endpoint.
 
-    Caches token→user_hash mappings in Redis so a burst of tool calls
-    from one session collapses to a single userinfo round-trip. The
-    cached ``user_hash`` is a stable HMAC of the OIDC ``sub`` claim, so
-    session state in Redis survives access-token rotation (previously,
-    a refresh silently orphaned the user's namespace).
+    Caches token→user_hash mappings in the session store so a burst of
+    tool calls from one session collapses to a single userinfo
+    round-trip. The cached ``user_hash`` is a stable HMAC of the OIDC
+    ``sub`` claim, so session state survives access-token rotation
+    (previously, a refresh silently orphaned the user's namespace).
 
     Revocation semantics:
     - A freshly-rejected token surfaces here as a 401 from userinfo →

--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -8,11 +8,8 @@ from fastmcp.tools import ToolResult
 from mcp.types import TextContent
 
 from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.mcp.session import get_session, json_default
 from courtlistener.mcp.tools import MCP_TOOLS
-from courtlistener.mcp.tools.utils import (
-    invalidate_token_cache,
-    json_default,
-)
 
 
 class ToolHandlerMiddleware(Middleware):
@@ -51,7 +48,7 @@ class ToolHandlerMiddleware(Middleware):
                 except RuntimeError:
                     access_token = None
                 if access_token is not None:
-                    await invalidate_token_cache(access_token.token)
+                    await get_session().invalidate_token(access_token.token)
                 raise ToolError(
                     "CourtListener rejected the request as unauthorized. "
                     "Your session may have expired; retry to re-authenticate."

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -68,6 +68,8 @@ def create_mcp_server(**kwargs):
     favicon_svg_path = assets_dir / "favicon.svg"
     favicon_ico_path = assets_dir / "favicon.ico"
     apple_touch_path = assets_dir / "apple-touch-icon.png"
+    index_html_path = assets_dir / "index.html"
+    icon_cache_headers = {"Cache-Control": "public, max-age=86400"}
 
     favicon_b64 = base64.b64encode(favicon_svg_path.read_bytes()).decode(
         "utf-8"
@@ -110,7 +112,7 @@ def create_mcp_server(**kwargs):
         return FileResponse(
             favicon_svg_path,
             media_type="image/svg+xml",
-            headers=ICON_CACHE_HEADERS,
+            headers=icon_cache_headers,
         )
 
     @mcp.custom_route("/favicon.ico", methods=["GET"])
@@ -118,7 +120,7 @@ def create_mcp_server(**kwargs):
         return FileResponse(
             favicon_ico_path,
             media_type="image/x-icon",
-            headers=ICON_CACHE_HEADERS,
+            headers=icon_cache_headers,
         )
 
     @mcp.custom_route("/apple-touch-icon.png", methods=["GET"])
@@ -126,13 +128,13 @@ def create_mcp_server(**kwargs):
         return FileResponse(
             apple_touch_path,
             media_type="image/png",
-            headers=ICON_CACHE_HEADERS,
+            headers=icon_cache_headers,
         )
 
     # Home page route
     @mcp.custom_route("/", methods=["GET"])
     async def index(request):
-        return HTMLResponse(INDEX_HTML)
+        return FileResponse(index_html_path, media_type="text/html")
 
     # OpenAI Apps directory domain-verification challenge
     @mcp.custom_route("/.well-known/openai-apps-challenge", methods=["GET"])

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -1,5 +1,4 @@
 import base64
-import os
 
 from fastmcp import FastMCP
 from fastmcp.server.auth.auth import (
@@ -14,53 +13,23 @@ from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import (
     FileResponse,
-    HTMLResponse,
     JSONResponse,
     PlainTextResponse,
 )
 from starlette.routing import Route
 
+from courtlistener.mcp import settings
 from courtlistener.mcp.auth import UserInfoTokenVerifier
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
 from courtlistener.mcp.prompts import GLOBAL_INSTRUCTIONS
-from courtlistener.mcp.tools.utils import (
+from courtlistener.mcp.settings import (
     BASE_DIR,
     GIT_SHA,
     MCP_BASE_URL,
     OAUTH_ISSUER,
+    OPENAI_APPS_CHALLENGE_TOKEN,
     REDIS_URL,
 )
-
-ICON_CACHE_HEADERS = {"Cache-Control": "public, max-age=86400"}
-
-OPENAI_APPS_CHALLENGE_TOKEN = "oR-QatCh96AHxvH1yYTS7_oP4ByrYVSuoCmAifKJyVg"
-
-INDEX_HTML = """<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>CourtListener MCP Server</title>
-<link rel="icon" href="/favicon.ico" sizes="any">
-<link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="apple-touch-icon" href="/apple-touch-icon.png">
-<meta name="google-site-verification" content="C8dEEUUkQm1uhzt8FLvr1mAKcuEOkMiTi5a0nFgs5Qw" />
-<meta name="description" content="MCP (Model Context Protocol) server for the CourtListener legal research API.">
-<style>
-body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; line-height: 1.5; color: #222; }
-a { color: #b53c2c; }
-code { background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
-</style>
-</head>
-<body>
-<h1>CourtListener MCP Server</h1>
-<p>This is the HTTP endpoint for the CourtListener Model Context Protocol server,
-which exposes the <a href="https://courtlistener.com">CourtListener</a> legal
-research API to MCP-compatible clients.</p>
-<p>See the <a href="https://wiki.free.law/c/courtlistener/help/api/mcp">MCP documentation</a> on the Free Law Wiki for setup instructions.</p>
-</body>
-</html>
-"""
 
 
 def create_mcp_server(**kwargs):
@@ -163,7 +132,7 @@ def create_mcp_server(**kwargs):
 
 def build_auth() -> AuthProvider | None:
     """Return an ``AuthProvider`` when OAuth is configured, else ``None``."""
-    if os.getenv("MCP_REQUIRE_OAUTH", "true").lower() != "true":
+    if not settings.MCP_REQUIRE_OAUTH:
         return None
     return RemoteAuthProvider(
         token_verifier=UserInfoTokenVerifier(base_url=MCP_BASE_URL),

--- a/courtlistener/mcp/session.py
+++ b/courtlistener/mcp/session.py
@@ -105,7 +105,9 @@ class Session:
     async def get_document(self, doc_type: str, doc_id: int) -> str | None:
         return await self._get(f"mcp:doc:{doc_type}:{doc_id}")
 
-    async def store_document(self, doc_type: str, doc_id: int, text: str) -> None:
+    async def store_document(
+        self, doc_type: str, doc_id: int, text: str
+    ) -> None:
         # Not user-scoped so that fetched documents are shared across users.
         await self._set(
             f"mcp:doc:{doc_type}:{doc_id}", text, DOCUMENT_TTL_SECONDS

--- a/courtlistener/mcp/session.py
+++ b/courtlistener/mcp/session.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from datetime import date, datetime
+from typing import Any
+
+import redis.asyncio as redis
+from fastmcp.server.dependencies import get_access_token
+
+from courtlistener import CourtListener
+from courtlistener.mcp import settings
+from courtlistener.mcp.settings import (
+    DOCUMENT_TTL_SECONDS,
+    MCP_SECRET_BYTES,
+    SESSION_TTL_SECONDS,
+    TOKEN_CACHE_TTL_SECONDS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def json_default(obj):
+    if isinstance(obj, (date, datetime)):
+        return obj.isoformat()
+    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+
+def hmac_hex(value: str) -> str:
+    return hmac.new(
+        MCP_SECRET_BYTES, value.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def user_hash(client: CourtListener) -> str:
+    """Return the stable per-user key prefix for the current request."""
+    try:
+        access_token = get_access_token()
+    except RuntimeError:
+        access_token = None
+
+    if access_token is not None:
+        uh = access_token.claims.get("user_hash")
+        if uh:
+            return uh
+
+    token = client.api_token or client.access_token
+    if not token:
+        raise ValueError("Client has no credential; cannot derive user hash.")
+    return hmac_hex(token)
+
+
+class Session:
+    """Storage backend for MCP server state."""
+
+    async def _get(self, key: str) -> str | None:
+        raise NotImplementedError("_get must be implemented by subclass")
+
+    async def _set(self, key: str, value: str, ttl_seconds: int) -> None:
+        raise NotImplementedError("_set must be implemented by subclass")
+
+    async def _delete(self, key: str) -> None:
+        raise NotImplementedError("_delete must be implemented by subclass")
+
+    async def _get_user_scoped(
+        self, client: CourtListener, suffix: str
+    ) -> Any:
+        raw = await self._get(f"mcp:{user_hash(client)}:{suffix}")
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    async def _set_user_scoped(
+        self, client: CourtListener, suffix: str, value: Any
+    ) -> None:
+        await self._set(
+            f"mcp:{user_hash(client)}:{suffix}",
+            json.dumps(value, default=json_default),
+            SESSION_TTL_SECONDS,
+        )
+
+    async def get_query(
+        self, query_id: str, client: CourtListener
+    ) -> dict | None:
+        return await self._get_user_scoped(client, f"query:{query_id}")
+
+    async def store_query(
+        self, query_id: str, data: dict, client: CourtListener
+    ) -> None:
+        await self._set_user_scoped(client, f"query:{query_id}", data)
+
+    async def get_citation_analysis(
+        self, job_id: str, client: CourtListener
+    ) -> dict | None:
+        return await self._get_user_scoped(client, f"citation:{job_id}")
+
+    async def store_citation_analysis(
+        self, job_id: str, data: dict, client: CourtListener
+    ) -> None:
+        await self._set_user_scoped(client, f"citation:{job_id}", data)
+
+    async def get_document(self, doc_type: str, doc_id: int) -> str | None:
+        return await self._get(f"mcp:doc:{doc_type}:{doc_id}")
+
+    async def store_document(self, doc_type: str, doc_id: int, text: str) -> None:
+        # Not user-scoped so that fetched documents are shared across users.
+        await self._set(
+            f"mcp:doc:{doc_type}:{doc_id}", text, DOCUMENT_TTL_SECONDS
+        )
+
+    async def get_user_hash(self, token: str) -> str | None:
+        return await self._get(f"mcp:token_to_user:{hmac_hex(token)}")
+
+    async def store_user_hash(self, token: str, uh: str) -> None:
+        await self._set(
+            f"mcp:token_to_user:{hmac_hex(token)}",
+            uh,
+            TOKEN_CACHE_TTL_SECONDS,
+        )
+
+    async def invalidate_token(self, token: str) -> None:
+        """Drop a token to user_hash mapping."""
+        try:
+            await self._delete(f"mcp:token_to_user:{hmac_hex(token)}")
+        except Exception as exc:
+            logger.warning("failed to invalidate token cache: %s", exc)
+
+
+class RedisSession(Session):
+    """Redis-backed session storage, shared across workers."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._client: redis.Redis | None = None
+
+    @property
+    def client(self) -> redis.Redis:
+        if self._client is None:
+            self._client = redis.from_url(
+                self._url, decode_responses=True, protocol=3
+            )
+        return self._client
+
+    async def _get(self, key: str) -> str | None:
+        return await self.client.get(key)
+
+    async def _set(self, key: str, value: str, ttl_seconds: int) -> None:
+        await self.client.set(key, value, ex=ttl_seconds)
+
+    async def _delete(self, key: str) -> None:
+        await self.client.delete(key)
+
+
+class InMemorySession(Session):
+    """Dict-backed session storage for local/stdio use without Redis."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[str, float]] = {}
+
+    async def _get(self, key: str) -> str | None:
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if time.monotonic() >= expires_at:
+            del self._data[key]
+            return None
+        return value
+
+    async def _set(self, key: str, value: str, ttl_seconds: int) -> None:
+        self._data[key] = (value, time.monotonic() + ttl_seconds)
+
+    async def _delete(self, key: str) -> None:
+        self._data.pop(key, None)
+
+
+_session: Session | None = None
+
+
+def get_session() -> Session:
+    """Return the process-wide session store, creating it on first use."""
+    global _session
+    if _session is None:
+        url = settings.REDIS_URL
+        if url:
+            _session = RedisSession(url)
+        else:
+            logger.warning(
+                "REDIS_URL is not set; using in-memory sessions. State "
+                "is per-process and will be lost on restart."
+            )
+            _session = InMemorySession()
+    return _session
+
+
+def set_session(session: Session | None) -> None:
+    """Replace the process-wide session store (for tests)."""
+    global _session
+    _session = session

--- a/courtlistener/mcp/settings.py
+++ b/courtlistener/mcp/settings.py
@@ -1,0 +1,64 @@
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+BASE_DIR = Path(__file__).parents[1]
+
+# Redis connection URL. In-memory storage is used when unset.
+REDIS_URL = os.getenv("REDIS_URL")
+
+# Deployed git SHA, reported by /health.
+GIT_SHA = os.getenv("GIT_SHA", "unknown")
+
+# Public base URL of this MCP server (the OAuth resource identifier).
+MCP_BASE_URL = os.getenv("MCP_BASE_URL", "https://mcp.courtlistener.com")
+
+# OAuth authorization server.
+OAUTH_ISSUER = os.getenv(
+    "COURTLISTENER_OAUTH_ISSUER", "https://www.courtlistener.com"
+)
+
+OAUTH_USERINFO_URL = os.getenv(
+    "COURTLISTENER_OAUTH_USERINFO_URL",
+    f"{OAUTH_ISSUER.rstrip('/')}/o/userinfo/",
+)
+
+# HMAC key for hashing tokens and user identifiers into storage keys.
+MCP_SECRET_KEY = os.getenv("MCP_SECRET_KEY")
+if not MCP_SECRET_KEY:
+    MCP_SECRET_KEY = "insecure-do-not-use-in-production"
+    logger.warning(
+        "MCP_SECRET_KEY is not set; falling back to an insecure default. "
+        "Set a strong random value before going to production."
+    )
+MCP_SECRET_BYTES = MCP_SECRET_KEY.encode("utf-8")
+
+# Sentry config
+SENTRY_DSN = os.getenv("SENTRY_DSN") or None
+SENTRY_TRACES_SAMPLE_RATE = float(
+    os.getenv("SENTRY_TRACES_SAMPLE_RATE") or 0.02
+)
+
+# How long a token to user_hash mapping is cached.
+TOKEN_CACHE_TTL_SECONDS = int(os.getenv("MCP_TOKEN_CACHE_TTL", "600"))
+
+# Whether the HTTP app requires OAuth.
+MCP_REQUIRE_OAUTH = os.getenv("MCP_REQUIRE_OAUTH", "true").lower() == "true"
+
+# Session-scoped state (query pagination, citation jobs) lives this long.
+SESSION_TTL_SECONDS = 3600 # 1 hour
+
+# How long a cached document lives in the session store (shared across users).
+DOCUMENT_TTL_SECONDS = 86400  # 24 hours
+
+# Timeout for the userinfo call made during token verification.
+USERINFO_TIMEOUT_SECONDS = 10
+
+# Result-count bounds for search/list tools.
+DEFAULT_NUM_RESULTS = 20
+MAX_NUM_RESULTS = 100
+
+# Domain-verification token for the OpenAI Apps directory listing.
+OPENAI_APPS_CHALLENGE_TOKEN = "oR-QatCh96AHxvH1yYTS7_oP4ByrYVSuoCmAifKJyVg"

--- a/courtlistener/mcp/settings.py
+++ b/courtlistener/mcp/settings.py
@@ -48,7 +48,7 @@ TOKEN_CACHE_TTL_SECONDS = int(os.getenv("MCP_TOKEN_CACHE_TTL", "600"))
 MCP_REQUIRE_OAUTH = os.getenv("MCP_REQUIRE_OAUTH", "true").lower() == "true"
 
 # Session-scoped state (query pagination, citation jobs) lives this long.
-SESSION_TTL_SECONDS = 3600 # 1 hour
+SESSION_TTL_SECONDS = 3600  # 1 hour
 
 # How long a cached document lives in the session store (shared across users).
 DOCUMENT_TTL_SECONDS = 86400  # 24 hours

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -8,6 +8,7 @@ from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.mcp.session import get_session
 from courtlistener.mcp.tools.citation_utils import (
     MAX_CITATIONS_PER_REQUEST,
     build_compact_string,
@@ -19,10 +20,7 @@ from courtlistener.mcp.tools.citation_utils import (
     process_api_results,
 )
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import (
-    make_id,
-    store_session_citation_analysis,
-)
+from courtlistener.mcp.tools.utils import make_id
 
 
 class AnalyzeCitationsTool(MCPTool):
@@ -183,7 +181,7 @@ class AnalyzeCitationsTool(MCPTool):
 
             # Step 4: Store in user-scoped session store
             analysis_id = make_id()
-            await store_session_citation_analysis(
+            await get_session().store_citation_analysis(
                 analysis_id,
                 {
                     "resource_refs": resource_refs,

--- a/courtlistener/mcp/tools/call_endpoint_tool.py
+++ b/courtlistener/mcp/tools/call_endpoint_tool.py
@@ -3,10 +3,12 @@ from typing import Any
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
-from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import (
+from courtlistener.mcp.settings import (
     DEFAULT_NUM_RESULTS,
     MAX_NUM_RESULTS,
+)
+from courtlistener.mcp.tools.mcp_tool import MCPTool
+from courtlistener.mcp.tools.utils import (
     collect_results,
     prepare_count,
     prepare_has_more_str,

--- a/courtlistener/mcp/tools/get_counts_tool.py
+++ b/courtlistener/mcp/tools/get_counts_tool.py
@@ -1,8 +1,8 @@
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.mcp.session import get_session
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import get_session_query
 from courtlistener.resource import ResourceIterator
 
 
@@ -38,7 +38,7 @@ class GetCountsTool(MCPTool):
     async def __call__(self, arguments: dict, ctx: Context) -> dict[str, int]:
         query_id = arguments["query_id"]
         with self.get_client() as client:
-            data = await get_session_query(query_id, client)
+            data = await get_session().get_query(query_id, client)
             if data is None:
                 raise ValueError(
                     f"Query ID {query_id!r} not found. The session may have "

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -1,16 +1,17 @@
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
-from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import (
+from courtlistener.mcp.session import get_session
+from courtlistener.mcp.settings import (
     DEFAULT_NUM_RESULTS,
     MAX_NUM_RESULTS,
+)
+from courtlistener.mcp.tools.mcp_tool import MCPTool
+from courtlistener.mcp.tools.utils import (
     collect_results,
     filter_results_by_fields,
-    get_session_query,
     has_more_results,
     prepare_has_more_str,
-    store_session_query,
 )
 from courtlistener.resource import ResourceIterator
 
@@ -60,7 +61,7 @@ class GetMoreResultsTool(MCPTool):
         num_results = arguments.get("num_results", DEFAULT_NUM_RESULTS)
 
         with self.get_client() as client:
-            query = await get_session_query(query_id, client)
+            query = await get_session().get_query(query_id, client)
             if query is None:
                 raise ValueError(
                     f"Query ID {query_id!r} not found. The session may have "
@@ -78,7 +79,7 @@ class GetMoreResultsTool(MCPTool):
             fields = query.get("fields")
             if fields is not None:
                 updated_data["fields"] = fields
-            await store_session_query(query_id, updated_data, client)
+            await get_session().store_query(query_id, updated_data, client)
 
             filtered_results, _ = filter_results_by_fields(results, fields)
 

--- a/courtlistener/mcp/tools/resume_citation_analysis_tool.py
+++ b/courtlistener/mcp/tools/resume_citation_analysis_tool.py
@@ -6,6 +6,7 @@ from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.mcp.session import get_session
 from courtlistener.mcp.tools.citation_utils import (
     MAX_CITATIONS_PER_REQUEST,
     build_compact_string,
@@ -14,10 +15,6 @@ from courtlistener.mcp.tools.citation_utils import (
     process_api_results,
 )
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import (
-    get_session_citation_analysis,
-    store_session_citation_analysis,
-)
 
 
 class ResumeCitationAnalysisTool(MCPTool):
@@ -67,7 +64,7 @@ class ResumeCitationAnalysisTool(MCPTool):
         job_id = arguments["job_id"]
         wait = bool(arguments.get("wait", False))
         with self.get_client() as client:
-            job = await get_session_citation_analysis(job_id, client)
+            job = await get_session().get_citation_analysis(job_id, client)
             if job is None:
                 raise ValueError(
                     f"Job ID {job_id!r} not found. The session may have expired."
@@ -102,6 +99,6 @@ class ResumeCitationAnalysisTool(MCPTool):
             )
             newly_verified = set(job["verified"].keys()) - previously_verified
 
-            await store_session_citation_analysis(job_id, job, client)
+            await get_session().store_citation_analysis(job_id, job, client)
 
             return format_resume(job_id, job, newly_verified)

--- a/courtlistener/mcp/tools/search_tool.py
+++ b/courtlistener/mcp/tools/search_tool.py
@@ -3,10 +3,12 @@ from typing import Any
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
-from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import (
+from courtlistener.mcp.settings import (
     DEFAULT_NUM_RESULTS,
     MAX_NUM_RESULTS,
+)
+from courtlistener.mcp.tools.mcp_tool import MCPTool
+from courtlistener.mcp.tools.utils import (
     collect_results,
     filter_results_by_fields,
     prepare_count,

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -1,77 +1,22 @@
-import hashlib
-import hmac
 import json
 import logging
-import os
 import uuid
-from datetime import date, datetime
 from itertools import islice
-from pathlib import Path
-from typing import Any
 
-import httpx
-import redis.asyncio as redis
 import tiktoken
-from fastmcp.server.dependencies import get_access_token
 
 from courtlistener import CourtListener
+from courtlistener.mcp.session import get_session
+from courtlistener.mcp.settings import DEFAULT_NUM_RESULTS
 from courtlistener.resource import ResourceIterator
 
 logger = logging.getLogger(__name__)
-
-BASE_DIR = Path(__file__).parents[2]
-
-DEFAULT_NUM_RESULTS = 20
-MAX_NUM_RESULTS = 100
-
-# Session-scoped keys live in Redis for this long before being evicted.
-SESSION_TTL_SECONDS = 3600
-
-# How long a token→user_hash mapping is cached.
-TOKEN_CACHE_TTL_SECONDS = int(os.getenv("MCP_TOKEN_CACHE_TTL", "600"))
-
-REDIS_URL = os.getenv("REDIS_URL")
-
-GIT_SHA = os.getenv("GIT_SHA", "unknown")
-
-MCP_BASE_URL = os.getenv("MCP_BASE_URL", "https://mcp.courtlistener.com")
-
-OAUTH_ISSUER = os.getenv(
-    "COURTLISTENER_OAUTH_ISSUER", "https://www.courtlistener.com"
-)
-
-OAUTH_USERINFO_URL = os.getenv(
-    "COURTLISTENER_OAUTH_USERINFO_URL",
-    f"{OAUTH_ISSUER.rstrip('/')}/o/userinfo/",
-)
-
-MCP_SECRET_KEY = os.getenv("MCP_SECRET_KEY")
-if not MCP_SECRET_KEY:
-    MCP_SECRET_KEY = "insecure-do-not-use-in-production"
-    logger.warning(
-        "MCP_SECRET_KEY is not set; falling back to an insecure default. "
-        "Set a strong random value before going to production."
-    )
-MCP_SECRET_BYTES = MCP_SECRET_KEY.encode("utf-8")
-
-redis_client: redis.Redis | None = None
-
-
-def json_default(obj):
-    if isinstance(obj, (date, datetime)):
-        return obj.isoformat()
-    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 
 def collect_results(
     response: ResourceIterator, num_results: int = DEFAULT_NUM_RESULTS
 ) -> list[dict]:
-    """Consume up to *num_results* items from a ResourceIterator.
-
-    Uses the iterator protocol so ``_page_result_index`` is kept in sync,
-    which means a subsequent ``dump()`` will capture the correct resume
-    point.
-    """
+    """Consume up to *num_results* items from a ResourceIterator."""
     return list(islice(response, num_results))
 
 
@@ -80,12 +25,12 @@ async def prepare_query_id(
     client: CourtListener,
     fields: list[str] | None = None,
 ) -> str:
-    """Store query response in Redis and return a short UUID query ID."""
+    """Store the query response and return a short UUID query ID."""
     query_id = make_id()
     data: dict = {"response": response.dump()}
     if fields is not None:
         data["fields"] = fields
-    await store_session_query(query_id, data, client)
+    await get_session().store_query(query_id, data, client)
     return query_id
 
 
@@ -217,217 +162,32 @@ def prepare_has_more_str(
     return None
 
 
-# User-scoped Redis session helpers.
-#
-# Keyed by an HMAC of the caller's API token rather than the MCP session id,
-# so state survives across stateless_http=True requests and across workers.
-def get_redis() -> redis.Redis:
-    """Lazily build a module-level async Redis client from REDIS_URL."""
-    global redis_client
-    if redis_client is None:
-        url = os.environ.get("REDIS_URL")
-        if not url:
-            raise RuntimeError(
-                "REDIS_URL is not set; cannot access session store."
-            )
-        redis_client = redis.from_url(url, decode_responses=True, protocol=3)
-    return redis_client
-
-
-def hmac_hex(value: str) -> str:
-    return hmac.new(
-        MCP_SECRET_BYTES, value.encode("utf-8"), hashlib.sha256
-    ).hexdigest()
-
-
-def token_cache_key(token: str) -> str:
-    """Redis key for the token→user_hash mapping set by the verifier."""
-    return f"mcp:token_to_user:{hmac_hex(token)}"
-
-
-async def resolve_user_hash_via_userinfo(token: str) -> str | None:
-    """Return the stable user_hash for *token*, hitting userinfo on cache miss.
-
-    Called from the auth verifier (see ``UserInfoTokenVerifier``). Returns
-    ``None`` if CL rejects the token, which the verifier translates into a
-    proper HTTP 401 at the auth layer.
-
-    The cache key is ``HMAC(token)``; the cache value is ``HMAC(sub)``. The
-    token never lands in Redis in plaintext, and the namespace is derived
-    from the stable OIDC ``sub`` claim so that rotated tokens still map to
-    the same user.
-    """
-    r = get_redis()
-    cache_key = token_cache_key(token)
-    cached = await r.get(cache_key)
-    if cached:
-        return cached
-
-    try:
-        async with httpx.AsyncClient(timeout=10) as http:
-            resp = await http.get(
-                OAUTH_USERINFO_URL,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-    except httpx.HTTPError as exc:
-        logger.warning("userinfo call failed: %s", exc)
-        return None
-
-    if resp.status_code != 200:
-        # 401 from userinfo == revoked/expired/invalid. Don't cache.
-        return None
-
-    sub = resp.json().get("sub")
-    if not sub:
-        logger.warning("userinfo response missing `sub` claim")
-        return None
-
-    uh = hmac_hex(str(sub))
-    await r.set(cache_key, uh, ex=TOKEN_CACHE_TTL_SECONDS)
-    return uh
-
-
-async def invalidate_token_cache(token: str) -> None:
-    """Drop a token→user_hash mapping.
-
-    Called when CL rejects a token mid-cache (e.g. 401 on a downstream
-    API call). The *next* MCP request for this token will miss the cache,
-    re-hit userinfo, fail, and cause a proper HTTP 401 from the auth layer
-    so the MCP client re-runs OAuth.
-    """
-    try:
-        await get_redis().delete(token_cache_key(token))
-    except Exception as exc:
-        logger.warning("failed to invalidate token cache: %s", exc)
-
-
-def user_hash(client: CourtListener) -> str:
-    """Return the stable per-user key prefix for the current request.
-
-    OAuth path: reads ``user_hash`` from the FastMCP access-token claims,
-    which ``UserInfoTokenVerifier`` populated from the OIDC ``sub`` at
-    verification time. The hash survives access-token rotation because it
-    is derived from ``sub``, not the raw token.
-
-    Legacy path: hashes the API token directly, matching the old behavior
-    for non-OAuth requests.
-    """
-    try:
-        access_token = get_access_token()
-    except RuntimeError:
-        access_token = None
-
-    if access_token is not None:
-        uh = access_token.claims.get("user_hash")
-        if uh:
-            return uh
-        # Should not happen: UserInfoTokenVerifier always sets this. If
-        # another verifier is in use, fall through to token-based hashing.
-
-    token = client.api_token or client.access_token
-    if not token:
-        raise ValueError("Client has no credential; cannot derive user hash.")
-    return hmac_hex(token)
-
-
-def redis_key(client: CourtListener, suffix: str) -> str:
-    return f"mcp:{user_hash(client)}:{suffix}"
-
-
 def make_id() -> str:
     """Generate a short, random UUID for session-scoped tool state."""
     return str(uuid.uuid4())[:8]
 
 
-async def set_user_scoped(
-    client: CourtListener, suffix: str, value: Any
-) -> None:
-    await get_redis().set(
-        redis_key(client, suffix),
-        json.dumps(value, default=json_default),
-        ex=SESSION_TTL_SECONDS,
-    )
-
-
-async def get_user_scoped(client: CourtListener, suffix: str) -> Any:
-    raw = await get_redis().get(redis_key(client, suffix))
-    if raw is None:
-        return None
-    return json.loads(raw)
-
-
-async def get_session_query(
-    query_id: str, client: CourtListener
-) -> dict | None:
-    return await get_user_scoped(client, f"query:{query_id}")
-
-
-async def store_session_query(
-    query_id: str, data: dict, client: CourtListener
-) -> None:
-    await set_user_scoped(client, f"query:{query_id}", data)
-
-
-# Document cache helpers.
-#
-# Keyed by doc_type and doc_id — not user-scoped — so the same document
-# is only fetched from the API once regardless of which user requests it.
-DOCUMENT_TTL_SECONDS = 86400  # 24 hours
-
-DOC_TYPE_CONFIG: dict[str, tuple[str, str]] = {
-    "opinion": ("opinions", "html_with_citations"),
-    "recap_document": ("recap_documents", "plain_text"),
-}
-
-
-def doc_cache_key(doc_type: str, doc_id: int) -> str:
-    return f"mcp:doc:{doc_type}:{doc_id}"
-
-
-async def get_cached_document(doc_type: str, doc_id: int) -> str | None:
-    return await get_redis().get(doc_cache_key(doc_type, doc_id))
-
-
-async def store_cached_document(doc_type: str, doc_id: int, text: str) -> None:
-    await get_redis().set(
-        doc_cache_key(doc_type, doc_id),
-        text,
-        ex=DOCUMENT_TTL_SECONDS,
-    )
-
-
 async def fetch_document_text(
     doc_type: str, doc_id: int, client: CourtListener
 ) -> str | None:
-    """Return full document text, fetching from the API on cache miss.
-
-    Shared between read_document and search_document tools so the same
-    document is only pulled from the API once per 24-hour window.
-    """
-    if doc_type not in DOC_TYPE_CONFIG:
+    """Return full document text, fetching from the API on cache miss."""
+    doc_types = {
+        "opinion": ("opinions", "html_with_citations"),
+        "recap_document": ("recap_documents", "plain_text"),
+    }
+    if doc_type not in doc_types:
         raise ValueError(f"Unknown doc_type: {doc_type!r}")
 
-    cached = await get_cached_document(doc_type, doc_id)
+    session = get_session()
+    cached = await session.get_document(doc_type, doc_id)
     if cached is not None:
         return cached
 
-    resource_name, field = DOC_TYPE_CONFIG[doc_type]
+    resource_name, field = doc_types[doc_type]
     item = getattr(client, resource_name).get(doc_id, fields=[field])
     text = item.get(field) or ""
 
     if text:
-        await store_cached_document(doc_type, doc_id, text)
+        await session.store_document(doc_type, doc_id, text)
 
     return text or None
-
-
-async def get_session_citation_analysis(
-    job_id: str, client: CourtListener
-) -> dict | None:
-    return await get_user_scoped(client, f"citation:{job_id}")
-
-
-async def store_session_citation_analysis(
-    job_id: str, data: dict, client: CourtListener
-) -> None:
-    await set_user_scoped(client, f"citation:{job_id}", data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ courtlistener-mcp = "courtlistener.mcp.server:main"
 [tool.setuptools.packages.find]
 include = ["courtlistener*"]
 
+[tool.setuptools.package-data]
+"courtlistener.mcp" = ["assets/*"]
+
 [tool.mypy]
 files = ["courtlistener"]
 python_version = "3.10"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -181,9 +181,9 @@ class TestServerAuthWiring:
             import importlib
 
             import courtlistener.mcp.server as server_mod
-            import courtlistener.mcp.tools.utils as utils_mod
+            import courtlistener.mcp.settings as settings_mod
 
-            importlib.reload(utils_mod)
+            importlib.reload(settings_mod)
             importlib.reload(server_mod)
             auth = server_mod.build_auth()
             verifier_cls = server_mod.UserInfoTokenVerifier
@@ -258,25 +258,47 @@ class TestServerAuthWiring:
         verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
         assert asyncio.run(verifier.verify_token("")) is None
 
-    def test_build_auth_accepts_true_case_insensitively(self):
-        """``MCP_REQUIRE_OAUTH=TRUE`` / ``True`` also enables OAuth."""
+    def test_build_auth_respects_require_oauth_setting(self):
+        """``build_auth`` reads ``settings.MCP_REQUIRE_OAUTH`` at call
+        time, so it can be patched like any other setting."""
         from courtlistener.mcp.server import build_auth
 
-        for value in ("true", "TRUE", "True"):
-            with patch.dict("os.environ", {"MCP_REQUIRE_OAUTH": value}):
-                assert build_auth() is not None, value
+        with patch("courtlistener.mcp.settings.MCP_REQUIRE_OAUTH", False):
+            assert build_auth() is None
+        with patch("courtlistener.mcp.settings.MCP_REQUIRE_OAUTH", True):
+            assert build_auth() is not None
 
-    def test_build_auth_ignores_other_truthy_values(self):
+    def test_require_oauth_parses_true_case_insensitively(self):
+        """``MCP_REQUIRE_OAUTH=TRUE`` / ``True`` also enables OAuth."""
+        import importlib
+
+        import courtlistener.mcp.settings as settings_mod
+
+        try:
+            for value in ("true", "TRUE", "True"):
+                with patch.dict("os.environ", {"MCP_REQUIRE_OAUTH": value}):
+                    importlib.reload(settings_mod)
+                    assert settings_mod.MCP_REQUIRE_OAUTH is True, value
+        finally:
+            importlib.reload(settings_mod)
+
+    def test_require_oauth_ignores_other_truthy_values(self):
         """Only the literal string ``true`` (any casing) enables OAuth.
 
         Prevents accidental activation from stray values like ``1`` or
         ``yes`` in deployment configs.
         """
-        from courtlistener.mcp.server import build_auth
+        import importlib
 
-        for value in ("1", "yes", "on", "True ", " true", "false", ""):
-            with patch.dict("os.environ", {"MCP_REQUIRE_OAUTH": value}):
-                assert build_auth() is None, value
+        import courtlistener.mcp.settings as settings_mod
+
+        try:
+            for value in ("1", "yes", "on", "True ", " true", "false", ""):
+                with patch.dict("os.environ", {"MCP_REQUIRE_OAUTH": value}):
+                    importlib.reload(settings_mod)
+                    assert settings_mod.MCP_REQUIRE_OAUTH is False, value
+        finally:
+            importlib.reload(settings_mod)
 
     def test_create_mcp_server_does_not_enable_auth_by_default(self):
         """Bare ``create_mcp_server`` should not wire in OAuth, even
@@ -304,13 +326,13 @@ class TestUserHash:
         change the hash because the claim is derived from the stable
         OIDC ``sub``.
         """
-        from courtlistener.mcp.tools.utils import user_hash
+        from courtlistener.mcp.session import user_hash
 
         client = CourtListener(access_token="any-token")
         fake_token = MagicMock()
         fake_token.claims = {"user_hash": "claim-derived-hash"}
         with patch(
-            "courtlistener.mcp.tools.utils.get_access_token",
+            "courtlistener.mcp.session.get_access_token",
             return_value=fake_token,
         ):
             assert user_hash(client) == "claim-derived-hash"
@@ -319,26 +341,26 @@ class TestUserHash:
         """Legacy / stdio path: no FastMCP context → HMAC the API token
         directly, matching pre-OAuth behavior.
         """
-        from courtlistener.mcp.tools.utils import hmac_hex, user_hash
+        from courtlistener.mcp.session import hmac_hex, user_hash
 
         client = CourtListener(api_token="legacy-token")
         with patch(
-            "courtlistener.mcp.tools.utils.get_access_token",
+            "courtlistener.mcp.session.get_access_token",
             side_effect=RuntimeError("no HTTP request"),
         ):
             assert user_hash(client) == hmac_hex("legacy-token")
 
     def test_raises_when_client_has_no_credential(self):
         """Defensive: a client with neither an access token nor an API
-        token should never reach the Redis layer."""
-        from courtlistener.mcp.tools.utils import user_hash
+        token should never reach the session store."""
+        from courtlistener.mcp.session import user_hash
 
         client = CourtListener.__new__(CourtListener)
         client.api_token = None
         client.access_token = None
         with (
             patch(
-                "courtlistener.mcp.tools.utils.get_access_token",
+                "courtlistener.mcp.session.get_access_token",
                 side_effect=RuntimeError("no HTTP request"),
             ),
             pytest.raises(ValueError, match="no credential"),
@@ -370,7 +392,9 @@ class TestHealthEndpoint:
             import importlib
 
             import courtlistener.mcp.server as server_mod
+            import courtlistener.mcp.settings as settings_mod
 
+            importlib.reload(settings_mod)
             importlib.reload(server_mod)
             mcp = server_mod.create_mcp_server(auth=server_mod.build_auth())
 
@@ -405,7 +429,9 @@ class TestOpenAIAppsChallenge:
             import importlib
 
             import courtlistener.mcp.server as server_mod
+            import courtlistener.mcp.settings as settings_mod
 
+            importlib.reload(settings_mod)
             importlib.reload(server_mod)
             mcp = server_mod.create_mcp_server(auth=server_mod.build_auth())
             token = server_mod.OPENAI_APPS_CHALLENGE_TOKEN

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,193 @@
+"""Tests for the Session abstraction: the in-memory backend, the
+Redis/in-memory fallback in ``get_session``, and the domain methods
+shared by both backends.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from courtlistener import CourtListener
+from courtlistener.mcp.session import (
+    InMemorySession,
+    RedisSession,
+    Session,
+    get_session,
+    set_session,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_session_singleton():
+    """Isolate the module-level singleton between tests."""
+    set_session(None)
+    yield
+    set_session(None)
+
+
+@pytest.fixture
+def client():
+    return CourtListener(api_token="test-token")
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class TestInMemorySession:
+    def test_get_missing_key_returns_none(self):
+        session = InMemorySession()
+        assert run(session._get("nope")) is None
+
+    def test_set_get_roundtrip(self):
+        session = InMemorySession()
+        run(session._set("key", "value", 60))
+        assert run(session._get("key")) == "value"
+
+    def test_delete(self):
+        session = InMemorySession()
+        run(session._set("key", "value", 60))
+        run(session._delete("key"))
+        assert run(session._get("key")) is None
+
+    def test_delete_missing_key_is_noop(self):
+        session = InMemorySession()
+        run(session._delete("nope"))
+
+    def test_expired_entry_returns_none_and_is_dropped(self):
+        import time
+
+        session = InMemorySession()
+        run(session._set("key", "value", 60))
+        # Rewind the stored expiry to simulate the TTL elapsing.
+        value, _ = session._data["key"]
+        session._data["key"] = (value, time.monotonic() - 1)
+        assert run(session._get("key")) is None
+        assert "key" not in session._data
+
+    def test_set_applies_ttl(self):
+        import time
+
+        session = InMemorySession()
+        before = time.monotonic()
+        run(session._set("key", "value", 60))
+        _, expires_at = session._data["key"]
+        assert before + 59 < expires_at <= time.monotonic() + 60
+
+
+class TestSessionDomainMethods:
+    """Domain methods run against the in-memory backend, exercising the
+    shared key layout and JSON round-trip on the base class."""
+
+    def test_query_roundtrip(self, client):
+        session = InMemorySession()
+        run(session.store_query("abc123", {"response": {"x": 1}}, client))
+        assert run(session.get_query("abc123", client)) == {
+            "response": {"x": 1}
+        }
+
+    def test_query_missing_returns_none(self, client):
+        session = InMemorySession()
+        assert run(session.get_query("nope", client)) is None
+
+    def test_queries_are_user_scoped(self, client):
+        session = InMemorySession()
+        other = CourtListener(api_token="other-token")
+        run(session.store_query("abc123", {"response": 1}, client))
+        assert run(session.get_query("abc123", other)) is None
+
+    def test_citation_analysis_roundtrip(self, client):
+        session = InMemorySession()
+        run(session.store_citation_analysis("job1", {"pending": []}, client))
+        assert run(session.get_citation_analysis("job1", client)) == {
+            "pending": []
+        }
+
+    def test_document_cache_roundtrip(self):
+        session = InMemorySession()
+        run(session.store_document("opinion", 42, "full text"))
+        assert run(session.get_document("opinion", 42)) == "full text"
+
+    def test_document_cache_is_not_user_scoped(self):
+        session = InMemorySession()
+        run(session.store_document("opinion", 42, "full text"))
+        # No client/user involved in the key at all.
+        assert run(session._get("mcp:doc:opinion:42")) == "full text"
+
+    def test_token_cache_roundtrip_and_invalidate(self):
+        session = InMemorySession()
+        run(session.store_user_hash("tok", "hash123"))
+        assert run(session.get_user_hash("tok")) == "hash123"
+        run(session.invalidate_token("tok"))
+        assert run(session.get_user_hash("tok")) is None
+
+    def test_token_never_stored_in_plaintext(self):
+        session = InMemorySession()
+        run(session.store_user_hash("secret-token", "hash123"))
+        assert not any("secret-token" in key for key in session._data)
+
+    def test_invalidate_token_swallows_backend_errors(self):
+        class ExplodingSession(Session):
+            async def _delete(self, key):
+                raise RuntimeError("backend down")
+
+        run(ExplodingSession().invalidate_token("tok"))
+
+    def test_values_must_be_json_serializable(self, client):
+        """Both backends JSON-round-trip, so non-serializable session
+        data fails in memory exactly as it would against Redis."""
+        session = InMemorySession()
+        with pytest.raises(TypeError):
+            run(session.store_query("abc", {"bad": object()}, client))
+
+
+class TestGetSessionFallback:
+    def test_redis_url_set_uses_redis(self):
+        with patch(
+            "courtlistener.mcp.settings.REDIS_URL", "redis://localhost:1"
+        ):
+            session = get_session()
+        assert isinstance(session, RedisSession)
+
+    def test_redis_url_unset_falls_back_to_memory(self):
+        with patch("courtlistener.mcp.settings.REDIS_URL", None):
+            session = get_session()
+        assert isinstance(session, InMemorySession)
+
+    def test_singleton_is_reused(self):
+        with patch("courtlistener.mcp.settings.REDIS_URL", None):
+            assert get_session() is get_session()
+
+    def test_set_session_overrides(self):
+        override = InMemorySession()
+        set_session(override)
+        assert get_session() is override
+
+    def test_redis_session_builds_client_lazily(self):
+        """Constructing the session must not connect; the client is
+        created on first use with decoded responses."""
+        session = RedisSession("redis://example.test:6379")
+        assert session._client is None
+        with patch(
+            "courtlistener.mcp.session.redis.from_url",
+            return_value=MagicMock(),
+        ) as from_url:
+            _ = session.client
+            _ = session.client
+        from_url.assert_called_once_with(
+            "redis://example.test:6379", decode_responses=True, protocol=3
+        )
+
+
+class TestBaseSessionIsAbstract:
+    def test_primitives_raise_not_implemented(self):
+        session = Session()
+        with pytest.raises(NotImplementedError):
+            run(session._get("k"))
+        with pytest.raises(NotImplementedError):
+            run(session._set("k", "v", 1))
+        with pytest.raises(NotImplementedError):
+            run(session._delete("k"))


### PR DESCRIPTION
Fixes #178 

Adds a `Session` abstraction and an implementation for redis session and in-memory session. The MCP uses in-memory as a fallback when REDIS_URL not set.

Also a handful of cosmetic code reorgs included in this PR:
- The html for the index page is now in an html file in assets, rather than hardcoded into server.py
- Settings.py module added as a singular place for all configuration / env vars (previously scattered about)
- Tools utils is now stripped of auth helpers, session helpers, and config settings, so that all that remains are actual shared methods for tools (previously was acting as a catch-all junkdrawer for shared utilities across the mcp).