### PR TITLE
Add sentry exempt exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Features:
 - Added in-memory session support for MCP server.
 
 Changes:
+- Add `SentryExemptToolError` for tool errors triaged as known noise, dropped from Sentry reporting via a `before_send` hook.
 - Add fallback handling for HTTP errors in MCP tool handler middleware.
 - Add error message for rate limit exceeded errors.
 - Add `SENTRY_TRACES_SAMPLE_RATE` env var to control the sample rate for Sentry traces.

--- a/courtlistener/mcp/app.py
+++ b/courtlistener/mcp/app.py
@@ -1,6 +1,7 @@
 import sentry_sdk
 from sentry_sdk.integrations.mcp import MCPIntegration
 
+from courtlistener.mcp.exceptions import before_send
 from courtlistener.mcp.server import create_http_app
 from courtlistener.mcp.settings import SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE
 
@@ -8,6 +9,7 @@ sentry_sdk.init(
     dsn=SENTRY_DSN,
     integrations=[MCPIntegration()],
     traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
+    before_send=before_send,
 )
 
 app = create_http_app()

--- a/courtlistener/mcp/exceptions.py
+++ b/courtlistener/mcp/exceptions.py
@@ -1,0 +1,13 @@
+from fastmcp.exceptions import ToolError
+
+
+class SentryExemptToolError(ToolError):
+    """A `ToolError` triaged as known noise; not reported to Sentry."""
+
+
+def before_send(event, hint):
+    """Sentry `before_send` hook: drop exempt-marked tool errors."""
+    exc_info = hint.get("exc_info")
+    if exc_info is not None and isinstance(exc_info[1], SentryExemptToolError):
+        return None
+    return event

--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -8,6 +8,7 @@ from fastmcp.tools import ToolResult
 from mcp.types import TextContent
 
 from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.mcp.exceptions import SentryExemptToolError
 from courtlistener.mcp.session import get_session, json_default
 from courtlistener.mcp.tools import MCP_TOOLS
 
@@ -54,7 +55,8 @@ class ToolHandlerMiddleware(Middleware):
                     "Your session may have expired; retry to re-authenticate."
                 ) from exc
             elif exc.status_code == 429:
-                raise ToolError(
+                # Exempt: Routine API rate limit errors.
+                raise SentryExemptToolError(
                     f"Rate limit exceeded: {exc}. For higher rate limits, "
                     "you can upgrade your membership at https://donate.free.law/forms/membership"
                 ) from exc

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -1,0 +1,89 @@
+"""Sentry exemption for triaged known-noise tool errors.
+
+Routine 429 throttling raises ``SentryExemptToolError``, which the
+``before_send`` hook drops. Everything else — including 401 session
+expiry and upstream 5xx — still reports to Sentry.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+
+from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.mcp.exceptions import (
+    SentryExemptToolError,
+    before_send,
+)
+from courtlistener.mcp.middleware import ToolHandlerMiddleware
+
+
+def _api_error(status_code: int, detail) -> CourtListenerAPIError:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    return CourtListenerAPIError(status_code, detail, response)
+
+
+async def _call_tool_raising(monkeypatch, exc):
+    async def fake_tool(arguments, ctx):
+        raise exc
+
+    monkeypatch.setattr(
+        "courtlistener.mcp.middleware.MCP_TOOLS", {"fake_tool": fake_tool}
+    )
+    context = MagicMock()
+    context.message.name = "fake_tool"
+    context.message.arguments = {}
+    context.fastmcp_context = MagicMock()
+    middleware = ToolHandlerMiddleware()
+    return await middleware.on_call_tool(context, call_next=MagicMock())
+
+
+class TestMiddlewareErrorClassification:
+    @pytest.mark.asyncio
+    async def test_429_raises_sentry_exempt_error(self, monkeypatch):
+        error = _api_error(
+            429, {"detail": "Request was throttled. Rate limit exceeded."}
+        )
+        with pytest.raises(SentryExemptToolError) as excinfo:
+            await _call_tool_raising(monkeypatch, error)
+        assert "Rate limit exceeded" in str(excinfo.value)
+        assert "donate.free.law" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_401_still_reports(self, monkeypatch):
+        error = _api_error(401, {"detail": "Invalid token."})
+        with pytest.raises(ToolError) as excinfo:
+            await _call_tool_raising(monkeypatch, error)
+        assert not isinstance(excinfo.value, SentryExemptToolError)
+
+    @pytest.mark.asyncio
+    async def test_upstream_500_still_reports(self, monkeypatch):
+        error = _api_error(500, {"detail": "Internal Server Error."})
+        with pytest.raises(ToolError) as excinfo:
+            await _call_tool_raising(monkeypatch, error)
+        assert not isinstance(excinfo.value, SentryExemptToolError)
+
+
+class TestBeforeSend:
+    def _hint_for(self, exc: BaseException) -> dict:
+        try:
+            raise exc
+        except BaseException:
+            return {"exc_info": sys.exc_info()}
+
+    def test_drops_exempt_errors(self):
+        event = {"event_id": "abc"}
+        hint = self._hint_for(SentryExemptToolError("Rate limit exceeded"))
+        assert before_send(event, hint) is None
+
+    def test_keeps_plain_tool_errors(self):
+        event = {"event_id": "abc"}
+        hint = self._hint_for(ToolError("CourtListener API error"))
+        assert before_send(event, hint) is event
+
+    def test_keeps_events_without_exc_info(self):
+        event = {"event_id": "abc"}
+        assert before_send(event, {}) is event


### PR DESCRIPTION
Fixes #206 

- Adds `SentryExemptToolError`
- Excludes these in sentry's before_send hook
- Converts 429 rate limit errors to SentryExemptToolError