### PR TITLE
Opinion vs cluster ids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,10 @@
 The following changes are not yet released, but are code complete:
 
 Features:
--
+- Add support for cluster_id in search_document, read_document, and analyze_citations tools.
 
 Changes:
--
+- Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.
 
 Fixes:
 -

--- a/courtlistener/mcp/prompts.py
+++ b/courtlistener/mcp/prompts.py
@@ -57,6 +57,11 @@ without loading the whole document. For opinions, they use the
 `html_with_citations` field (the most reliable text source, with inline
 citation markup); for RECAP documents, they use `plain_text`.
 
+Opinion ids and cluster ids are separate id-spaces. A search result's
+`cluster_id` is NOT an opinion id — pass the result's top-level `opinion_id`
+to these tools, or pass `cluster_id` and they will resolve the cluster's
+opinion(s) for you.
+
 When fetching opinion or RECAP document records via `call_endpoint` or
 `get_endpoint_item`, exclude text fields (`html_with_citations`, `plain_text`,
 `html`, `html_lawbox`, etc.) from the fields you request — they can be
@@ -72,7 +77,9 @@ ID (normally a case-name slug). Without it, the link 404s. When you don't
 have a slug, repeat the resource name as the trailing segment:
 
     https://www.courtlistener.com/docket/{docket_id}/docket/
-    https://www.courtlistener.com/opinion/{opinion_id}/opinion/
+    https://www.courtlistener.com/opinion/{cluster_id}/opinion/
+
+Note that opinion URLs take the *cluster* id, not an opinion id.
 
 This is the safest format — it always resolves correctly even though it
 looks redundant.

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -111,15 +111,20 @@ class AnalyzeCitationsTool(MCPTool):
 
         note = ""
         with self.get_client() as client:
+            siblings = ""
             if cluster_id is not None:
                 resolved = resolve_cluster_opinion_ids(cluster_id, client)
                 opinion_id = resolved[0]
                 if len(resolved) > 1:
+                    siblings = (
+                        "Analyze the others separately, one call per "
+                        "opinion_id: "
+                        f"{', '.join(str(i) for i in resolved[1:])}."
+                    )
                     note = (
                         f"Analyzed opinion {opinion_id}, the main opinion "
                         f"of {len(resolved)} in cluster {cluster_id}. "
-                        "Analyze the others separately with opinion_id: "
-                        f"{resolved[1:]}.\n\n"
+                        f"{siblings}\n\n"
                     )
 
             if opinion_id is not None:
@@ -129,7 +134,7 @@ class AnalyzeCitationsTool(MCPTool):
                     if cluster_id is not None:
                         raise ValueError(
                             f"Text not available for opinion {opinion_id} "
-                            f"of cluster {cluster_id}."
+                            f"of cluster {cluster_id}. {siblings}".strip()
                         )
                     raise ValueError(
                         "Text not available for opinion ID. If this id "

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -20,7 +20,10 @@ from courtlistener.mcp.tools.citation_utils import (
     process_api_results,
 )
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import make_id
+from courtlistener.mcp.tools.utils import (
+    make_id,
+    resolve_cluster_opinion_ids,
+)
 
 
 class AnalyzeCitationsTool(MCPTool):
@@ -80,6 +83,16 @@ class AnalyzeCitationsTool(MCPTool):
                         "in CourtListener, you can provide the opinion ID"
                     ),
                 },
+                "cluster_id": {
+                    "type": "integer",
+                    "description": (
+                        "ID of an opinion cluster (the `cluster_id` in "
+                        "search results).  Analyzes the case's main "
+                        "opinion; ids for any concurrences or dissents "
+                        "are named in the output so they can be "
+                        "analyzed separately."
+                    ),
+                },
             },
             "required": [],
             "additionalProperties": False,
@@ -88,23 +101,52 @@ class AnalyzeCitationsTool(MCPTool):
     async def __call__(self, arguments: dict, ctx: Context) -> str:
         text = arguments.get("text")
         opinion_id = arguments.get("opinion_id")
-        if (text is not None) == (opinion_id is not None):
+        cluster_id = arguments.get("cluster_id")
+
+        provided = [
+            value
+            for value in (text, opinion_id, cluster_id)
+            if value is not None
+        ]
+        if len(provided) != 1:
             raise ValueError(
-                "Exactly one of text or opinion ID must be provided."
+                "Provide exactly one of text, opinion_id, or cluster_id."
             )
 
+        note = ""
         with self.get_client() as client:
+            if cluster_id is not None:
+                resolved = resolve_cluster_opinion_ids(cluster_id, client)
+                opinion_id = resolved[0]
+                if len(resolved) > 1:
+                    note = (
+                        f"Analyzed opinion {opinion_id}, the main opinion "
+                        f"of {len(resolved)} in cluster {cluster_id}. "
+                        "Analyze the others separately with opinion_id: "
+                        f"{resolved[1:]}.\n\n"
+                    )
+
             if opinion_id is not None:
                 opinion = client.opinions.get(opinion_id)
                 text = opinion.get("html_with_citations")
                 if not text:
-                    raise ValueError("Text not available for opinion ID.")
+                    if cluster_id is not None:
+                        raise ValueError(
+                            f"Text not available for opinion {opinion_id} "
+                            f"of cluster {cluster_id}."
+                        )
+                    raise ValueError(
+                        "Text not available for opinion ID. If this id "
+                        "came from a search result it may be a "
+                        "cluster_id, which is a separate id-space; pass "
+                        "it as cluster_id instead."
+                    )
 
             # Step 1: Local extraction and resolution
             assert text is not None  # for mypy
             cites = get_citations(text)
             if not cites:
-                return "No citations found."
+                return note + "No citations found."
 
             resolutions = resolve_citations(cites)
 
@@ -210,4 +252,4 @@ class AnalyzeCitationsTool(MCPTool):
                     rate_limit_detail,
                     resumable_with="resume_citation_analysis",
                 )
-            return output
+            return note + output

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -34,10 +34,6 @@ class AnalyzeCitationsTool(MCPTool):
     citation-lookup API. Returns case name, date, citation count,
     and verification status for each citation.
 
-    Uses a compact string strategy: only unique citation strings are
-    sent to the API (not the full document text), minimizing payload
-    size and API usage.
-
     For documents with more than 250 unique case citations, the first
     batch is verified immediately and a job_id is returned. Use
     resume_citation_analysis to continue verifying remaining citations.

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -8,6 +8,7 @@ from courtlistener.mcp.settings import (
 )
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import (
+    add_opinion_ids,
     collect_results,
     filter_results_by_fields,
     has_more_results,
@@ -75,6 +76,7 @@ class GetMoreResultsTool(MCPTool):
                 return f"No more results available for query {query_id!r}."
 
             results = collect_results(response, num_results)
+            add_opinion_ids(results)
 
             updated_data = {"response": response.dump()}
             fields = query.get("fields")

--- a/courtlistener/mcp/tools/read_document_tool.py
+++ b/courtlistener/mcp/tools/read_document_tool.py
@@ -4,7 +4,10 @@ from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import fetch_document_text
+from courtlistener.mcp.tools.utils import (
+    fetch_document_text,
+    resolve_cluster_opinion_ids,
+)
 
 DEFAULT_CHUNK_SIZE = 8000
 MAX_CHUNKS_PER_CALL = 10
@@ -17,9 +20,6 @@ class ReadDocumentTool(MCPTool):
     more paginated chunks.  For opinions, uses the ``html_with_citations``
     field (the most complete text representation).  For RECAP documents,
     uses ``plain_text``.
-
-    Document text is cached for 24 hours so repeated reads—whether by
-    the same user or different users—only hit the API once.
 
     **Usage patterns**
 
@@ -56,6 +56,15 @@ class ReadDocumentTool(MCPTool):
                     "type": "integer",
                     "description": "ID of the RECAP document to read.",
                 },
+                "cluster_id": {
+                    "type": "integer",
+                    "description": (
+                        "ID of an opinion cluster (the `cluster_id` in "
+                        "search results).  Reads the case's main "
+                        "opinion; ids for any concurrences or dissents "
+                        "are returned in `sibling_opinion_ids`."
+                    ),
+                },
                 "chunk_index": {
                     "anyOf": [
                         {"type": "integer", "minimum": 0},
@@ -87,38 +96,63 @@ class ReadDocumentTool(MCPTool):
     async def __call__(self, arguments: dict, ctx: Context) -> dict:
         opinion_id = arguments.get("opinion_id")
         recap_document_id = arguments.get("recap_document_id")
+        cluster_id = arguments.get("cluster_id")
 
-        if (opinion_id is None) == (recap_document_id is None):
+        provided = [
+            value
+            for value in (opinion_id, recap_document_id, cluster_id)
+            if value is not None
+        ]
+        if len(provided) != 1:
             raise ValueError(
-                "Provide exactly one of opinion_id or recap_document_id."
+                "Provide exactly one of opinion_id, recap_document_id, "
+                "or cluster_id."
             )
-
-        if opinion_id is not None:
-            doc_type, doc_id = "opinion", opinion_id
-        else:
-            doc_type, doc_id = "recap_document", recap_document_id
 
         chunk_index = arguments.get("chunk_index")
         chunk_size = arguments.get("chunk_size", DEFAULT_CHUNK_SIZE)
 
+        siblings: list[int] = []
         with self.get_client() as client:
-            text = await fetch_document_text(doc_type, doc_id, client)
+            if cluster_id is not None:
+                resolved = resolve_cluster_opinion_ids(cluster_id, client)
+                doc_type, doc_id = "opinion", resolved[0]
+                siblings = resolved[1:]
+            elif opinion_id is not None:
+                doc_type, doc_id = "opinion", opinion_id
+            else:
+                assert recap_document_id is not None  # for mypy
+                doc_type, doc_id = "recap_document", recap_document_id
+
+            try:
+                text = await fetch_document_text(doc_type, doc_id, client)
+            except Exception as exc:
+                # In cluster mode the resolution already succeeded, so
+                # keep the sibling ids usable instead of losing them to
+                # a bare error on the first opinion.
+                if cluster_id is None:
+                    raise
+                failure: dict = {
+                    "doc_type": doc_type,
+                    "doc_id": doc_id,
+                    "error": str(exc),
+                }
+                if siblings:
+                    failure["sibling_opinion_ids"] = siblings
+                return failure
+
+        result: dict = {"doc_type": doc_type, "doc_id": doc_id}
+        if siblings:
+            result["sibling_opinion_ids"] = siblings
 
         if not text:
-            return {
-                "doc_type": doc_type,
-                "doc_id": doc_id,
-                "error": "No text is available for this document.",
-            }
+            result["error"] = "No text is available for this document."
+            return result
 
         total_chars = len(text)
         total_chunks = math.ceil(total_chars / chunk_size)
 
-        result: dict = {
-            "doc_type": doc_type,
-            "doc_id": doc_id,
-            "total_chars": total_chars,
-        }
+        result["total_chars"] = total_chars
 
         if chunk_index is None:
             result["text"] = text

--- a/courtlistener/mcp/tools/search_document_tool.py
+++ b/courtlistener/mcp/tools/search_document_tool.py
@@ -4,7 +4,10 @@ from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import fetch_document_text
+from courtlistener.mcp.tools.utils import (
+    fetch_document_text,
+    resolve_cluster_opinion_ids,
+)
 
 DEFAULT_SNIPPET_SIZE = 300
 MAX_SNIPPETS = 20
@@ -71,6 +74,15 @@ class SearchDocumentTool(MCPTool):
                         f"(up to {MAX_DOCS_PER_CALL})."
                     ),
                 },
+                "cluster_id": {
+                    "type": "integer",
+                    "description": (
+                        "ID of an opinion cluster (the `cluster_id` in "
+                        "search results).  Searches the case's main "
+                        "opinion; ids for any concurrences or dissents "
+                        "are returned in `sibling_opinion_ids`."
+                    ),
+                },
                 "query": {
                     "type": "string",
                     "description": (
@@ -118,58 +130,65 @@ class SearchDocumentTool(MCPTool):
         snippet_size: int,
         client,
     ) -> dict:
+        result: dict = {"doc_type": doc_type, "doc_id": doc_id, "query": query}
+
         try:
             text = await fetch_document_text(doc_type, doc_id, client)
         except Exception as exc:
-            return {
-                "doc_type": doc_type,
-                "doc_id": doc_id,
-                "query": query,
-                "error": str(exc),
-            }
+            result["error"] = str(exc)
+            return result
 
         if not text:
-            return {
-                "doc_type": doc_type,
-                "doc_id": doc_id,
-                "query": query,
-                "error": "No text is available for this document.",
-            }
+            result["error"] = "No text is available for this document."
+            return result
 
         match_count, snippets = self._search_text(text, query, snippet_size)
-        return {
-            "doc_type": doc_type,
-            "doc_id": doc_id,
-            "query": query,
-            "total_chars": len(text),
-            "match_count": match_count,
-            "shown": len(snippets),
-            "snippets": snippets,
-        }
+        result.update(
+            {
+                "total_chars": len(text),
+                "match_count": match_count,
+                "shown": len(snippets),
+                "snippets": snippets,
+            }
+        )
+        return result
 
     async def __call__(self, arguments: dict, ctx: Context) -> dict:
         opinion_id = arguments.get("opinion_id")
         recap_document_id = arguments.get("recap_document_id")
+        cluster_id = arguments.get("cluster_id")
 
-        if (opinion_id is None) == (recap_document_id is None):
+        provided = [
+            value
+            for value in (opinion_id, recap_document_id, cluster_id)
+            if value is not None
+        ]
+        if len(provided) != 1:
             raise ValueError(
-                "Provide exactly one of opinion_id or recap_document_id."
+                "Provide exactly one of opinion_id, recap_document_id, "
+                "or cluster_id."
             )
-
-        if opinion_id is not None:
-            doc_type = "opinion"
-            raw = opinion_id
-        else:
-            doc_type = "recap_document"
-            raw = recap_document_id
-
-        multi = isinstance(raw, list)
-        doc_ids: list[int] = raw if multi else [raw]
 
         query: str = arguments["query"]
         snippet_size = arguments.get("snippet_size", DEFAULT_SNIPPET_SIZE)
 
+        multi = False
+        siblings: list[int] = []
+
         with self.get_client() as client:
+            if cluster_id is not None:
+                doc_type = "opinion"
+                resolved = resolve_cluster_opinion_ids(cluster_id, client)
+                doc_ids = resolved[:1]
+                siblings = resolved[1:]
+            else:
+                if opinion_id is not None:
+                    doc_type, raw = "opinion", opinion_id
+                else:
+                    doc_type, raw = "recap_document", recap_document_id
+                multi = isinstance(raw, list)
+                doc_ids = raw if isinstance(raw, list) else [raw]
+
             results = [
                 await self._search_one(
                     doc_type, doc_id, query, snippet_size, client
@@ -179,4 +198,8 @@ class SearchDocumentTool(MCPTool):
 
         if multi:
             return {"results": results}
-        return results[0]
+
+        result = results[0]
+        if siblings:
+            result["sibling_opinion_ids"] = siblings
+        return result

--- a/courtlistener/mcp/tools/search_tool.py
+++ b/courtlistener/mcp/tools/search_tool.py
@@ -9,6 +9,7 @@ from courtlistener.mcp.settings import (
 )
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import (
+    add_opinion_ids,
     collect_results,
     filter_results_by_fields,
     prepare_count,
@@ -107,6 +108,7 @@ class SearchTool(MCPTool):
 
             response = client.search.list(**arguments)
             results = collect_results(response, num_results)
+            add_opinion_ids(results)
 
             query_id = await prepare_query_id(response, client, fields=fields)
             count = prepare_count(response.current_page.count, query_id)

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -223,3 +223,59 @@ async def fetch_document_text(
         await session.store_document(doc_type, doc_id, text)
 
     return text or None
+
+
+ORDERED_OPINION_TYPES = (
+    ("020lead", "lead-opinion"),
+    ("010combined", "combined-opinion"),
+    ("015unamimous", "unanimous-opinion"),  # misspelled in the API
+    ("025plurality", "plurality-opinion"),
+    ("080onthemerits", "on-the-merits"),
+)
+OPINION_TYPE_RANK = {
+    spelling: rank
+    for rank, spellings in enumerate(ORDERED_OPINION_TYPES)
+    for spelling in spellings
+}
+
+
+def opinion_sort_key(opinion: dict) -> tuple[int, int, int]:
+    """Rank an opinion so the court's main opinion sorts first."""
+    ordering_key = opinion.get("ordering_key")
+    opinion_type: str = opinion.get("type") or ""
+    return (
+        ordering_key if isinstance(ordering_key, int) else 99999,
+        OPINION_TYPE_RANK.get(opinion_type, len(ORDERED_OPINION_TYPES)),
+        opinion.get("id") or 0,
+    )
+
+
+def add_opinion_ids(results: list[dict]) -> None:
+    """Copy each opinion search result's main opinion id to top level."""
+    for result in results:
+        opinions = [
+            opinion
+            for opinion in result.get("opinions") or []
+            if isinstance(opinion, dict) and opinion.get("id") is not None
+        ]
+        if opinions:
+            main = min(opinions, key=opinion_sort_key)
+            result.setdefault("opinion_id", main["id"])
+
+
+def resolve_cluster_opinion_ids(
+    cluster_id: int, client: CourtListener
+) -> list[int]:
+    """Return a cluster's opinion ids, main opinion first."""
+    response = client.opinions.list(
+        cluster=cluster_id, fields=["id", "type", "ordering_key"]
+    )
+    opinions = [
+        opinion
+        for opinion in collect_results(response, 20)
+        if opinion.get("id") is not None
+    ]
+    if not opinions:
+        raise ValueError(f"Cluster {cluster_id} has no opinions.")
+    opinions.sort(key=opinion_sort_key)
+    return [opinion["id"] for opinion in opinions]

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -69,7 +69,15 @@ def filter_results_by_fields(
     if not fields:
         return results, False
     missing = any(k not in result for result in results for k in fields)
-    filtered = [{k: v for k, v in r.items() if k in fields} for r in results]
+    filtered = [
+        {
+            k: v
+            for k, v in r.items()
+            # Always keep opinion_id to avoid cluster_id confusion
+            if k in fields or k == "opinion_id"
+        }
+        for r in results
+    ]
     return filtered, missing
 
 

--- a/docs/mcp/tools/analyze_citations.inputs.json
+++ b/docs/mcp/tools/analyze_citations.inputs.json
@@ -8,6 +8,10 @@
     "opinion_id": {
       "type": "integer",
       "description": "Alternatively, if the opinion is available in CourtListener, you can provide the opinion ID"
+    },
+    "cluster_id": {
+      "type": "integer",
+      "description": "ID of an opinion cluster (the `cluster_id` in search results).  Analyzes the case's main opinion; ids for any concurrences or dissents are named in the output so they can be analyzed separately."
     }
   },
   "required": [],

--- a/docs/mcp/tools/analyze_citations.md
+++ b/docs/mcp/tools/analyze_citations.md
@@ -5,8 +5,8 @@
 **Analyze Citations**
 
 - **Source:** `courtlistener/mcp/tools/analyze_citations_tool.py`
-- **Estimated definition size:** ~420 tokens (description ~244, input schema ~84; cl100k_base)
-- **Parameters:** 2 (0 required)
+- **Estimated definition size:** ~445 tokens (description ~213, input schema ~142; cl100k_base)
+- **Parameters:** 3 (0 required)
 - **Raw input schema:** [`analyze_citations.inputs.json`](./analyze_citations.inputs.json)
 
 ## Description
@@ -17,10 +17,6 @@ Extracts all citations locally using eyecite, then verifies each
 unique case citation against CourtListener's database via the
 citation-lookup API. Returns case name, date, citation count,
 and verification status for each citation.
-
-Uses a compact string strategy: only unique citation strings are
-sent to the API (not the full document text), minimizing payload
-size and API usage.
 
 For documents with more than 250 unique case citations, the first
 batch is verified immediately and a job_id is returned. Use
@@ -61,3 +57,9 @@ Legal text to analyze. Citations will be extracted locally and verified against 
 integer · optional
 
 Alternatively, if the opinion is available in CourtListener, you can provide the opinion ID
+
+### `cluster_id`
+
+integer · optional
+
+ID of an opinion cluster (the `cluster_id` in search results).  Analyzes the case's main opinion; ids for any concurrences or dissents are named in the output so they can be analyzed separately.

--- a/docs/mcp/tools/read_document.inputs.json
+++ b/docs/mcp/tools/read_document.inputs.json
@@ -9,6 +9,10 @@
       "type": "integer",
       "description": "ID of the RECAP document to read."
     },
+    "cluster_id": {
+      "type": "integer",
+      "description": "ID of an opinion cluster (the `cluster_id` in search results).  Reads the case's main opinion; ids for any concurrences or dissents are returned in `sibling_opinion_ids`."
+    },
     "chunk_index": {
       "anyOf": [
         {

--- a/docs/mcp/tools/read_document.md
+++ b/docs/mcp/tools/read_document.md
@@ -5,8 +5,8 @@
 **Read Document**
 
 - **Source:** `courtlistener/mcp/tools/read_document_tool.py`
-- **Estimated definition size:** ~531 tokens (description ~255, input schema ~195; cl100k_base)
-- **Parameters:** 4 (0 required)
+- **Estimated definition size:** ~558 tokens (description ~227, input schema ~252; cl100k_base)
+- **Parameters:** 5 (0 required)
 - **Raw input schema:** [`read_document.inputs.json`](./read_document.inputs.json)
 
 ## Description
@@ -17,9 +17,6 @@ Fetches the document text and either returns it in full or as one or
 more paginated chunks.  For opinions, uses the ``html_with_citations``
 field (the most complete text representation).  For RECAP documents,
 uses ``plain_text``.
-
-Document text is cached for 24 hours so repeated reads—whether by
-the same user or different users—only hit the API once.
 
 **Usage patterns**
 
@@ -57,6 +54,12 @@ ID of the opinion to read.
 integer · optional
 
 ID of the RECAP document to read.
+
+### `cluster_id`
+
+integer · optional
+
+ID of an opinion cluster (the `cluster_id` in search results).  Reads the case's main opinion; ids for any concurrences or dissents are returned in `sibling_opinion_ids`.
 
 ### `chunk_index`
 

--- a/docs/mcp/tools/search_document.inputs.json
+++ b/docs/mcp/tools/search_document.inputs.json
@@ -33,6 +33,10 @@
       ],
       "description": "ID or list of IDs of RECAP documents to search (up to 10)."
     },
+    "cluster_id": {
+      "type": "integer",
+      "description": "ID of an opinion cluster (the `cluster_id` in search results).  Searches the case's main opinion; ids for any concurrences or dissents are returned in `sibling_opinion_ids`."
+    },
     "query": {
       "type": "string",
       "description": "Literal phrase to search for (case-insensitive). Up to 20 matches are returned per document."

--- a/docs/mcp/tools/search_document.md
+++ b/docs/mcp/tools/search_document.md
@@ -5,8 +5,8 @@
 **Search Document**
 
 - **Source:** `courtlistener/mcp/tools/search_document_tool.py`
-- **Estimated definition size:** ~474 tokens (description ~170, input schema ~229; cl100k_base)
-- **Parameters:** 4 (1 required)
+- **Estimated definition size:** ~531 tokens (description ~170, input schema ~286; cl100k_base)
+- **Parameters:** 5 (1 required)
 - **Raw input schema:** [`search_document.inputs.json`](./search_document.inputs.json)
 
 ## Description
@@ -49,6 +49,12 @@ ID or list of IDs of opinions to search (up to 10).
 integer | array of integer · optional
 
 ID or list of IDs of RECAP documents to search (up to 10).
+
+### `cluster_id`
+
+integer · optional
+
+ID of an opinion cluster (the `cluster_id` in search results).  Searches the case's main opinion; ids for any concurrences or dissents are returned in `sibling_opinion_ids`.
 
 ### `query`
 

--- a/tests/test_mcp_document_ids.py
+++ b/tests/test_mcp_document_ids.py
@@ -1,0 +1,448 @@
+"""Cluster-id vs opinion-id handling in the document tools (issue #208).
+
+Opinion search results identify a case by ``cluster_id``, but the
+document tools take opinion ids — separate, overlapping id-spaces.
+Passing the search result's id used to silently read whatever opinion
+shared that integer.  These tests cover the two mitigations: the
+added top-level ``opinion_id`` in search results, and ``cluster_id``
+arguments on the tools that take a document id.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from courtlistener.mcp.session import InMemorySession, get_session, set_session
+from courtlistener.mcp.tools import MCP_TOOLS
+from courtlistener.mcp.tools.analyze_citations_tool import AnalyzeCitationsTool
+from courtlistener.mcp.tools.get_more_results_tool import GetMoreResultsTool
+from courtlistener.mcp.tools.read_document_tool import ReadDocumentTool
+from courtlistener.mcp.tools.search_document_tool import SearchDocumentTool
+from courtlistener.mcp.tools.search_tool import SearchTool
+from courtlistener.mcp.tools.utils import (
+    add_opinion_ids,
+    resolve_cluster_opinion_ids,
+)
+
+
+class FakeIterator:
+    """The slice of the ResourceIterator interface the tools consume."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.current_page = SimpleNamespace(
+            results=self._results, count=len(self._results)
+        )
+        self._page_result_index = len(self._results)
+
+    def __iter__(self):
+        return iter(self._results)
+
+    def has_next(self):
+        return False
+
+    def dump(self):
+        return {}
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def in_memory_session():
+    set_session(InMemorySession())
+    yield
+    set_session(None)
+
+
+def make_client(
+    opinion_texts: dict[int, str] | None = None,
+    cluster_opinions: dict[int, list[int] | list[dict]] | None = None,
+):
+    """A client mock serving the fetches the document tools perform.
+
+    ``cluster_opinions`` maps a cluster id to its opinions, given either
+    as bare ids or as dicts when a test cares about ``type`` order.
+    """
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+
+    def opinions_get(doc_id, fields=None):
+        return {"html_with_citations": (opinion_texts or {}).get(doc_id, "")}
+
+    def opinions_list(cluster=None, fields=None):
+        opinions = (cluster_opinions or {}).get(cluster, [])
+        return FakeIterator(
+            [
+                opinion if isinstance(opinion, dict) else {"id": opinion}
+                for opinion in opinions
+            ]
+        )
+
+    client.opinions.get.side_effect = opinions_get
+    client.opinions.list.side_effect = opinions_list
+    return client
+
+
+class TestAddOpinionIds:
+    def test_adds_the_nested_opinion_id(self):
+        results = [{"cluster_id": 8695893, "opinions": [{"id": 8678997}]}]
+        add_opinion_ids(results)
+        assert results[0]["opinion_id"] == 8678997
+
+    def test_picks_the_main_opinion_not_the_first_listed(self):
+        """Citizens United as `search` really returns it: the nested
+        opinions come back in relevance order, so entry [0] is Stevens'
+        partial dissent and the majority sits fourth.  Search spells the
+        types differently from the REST API, so both must rank."""
+        results = [
+            {
+                "cluster_id": 1741,
+                "opinions": [
+                    {
+                        "id": 9413190,
+                        "type": "in-part-opinion",
+                        "ordering_key": 4,
+                    },
+                    {
+                        "id": 1741,
+                        "type": "combined-opinion",
+                        "ordering_key": None,
+                    },
+                    {
+                        "id": 9413191,
+                        "type": "in-part-opinion",
+                        "ordering_key": 5,
+                    },
+                    {
+                        "id": 9413187,
+                        "type": "lead-opinion",
+                        "ordering_key": 1,
+                    },
+                ],
+            }
+        ]
+        add_opinion_ids(results)
+        assert results[0]["opinion_id"] == 9413187
+
+    def test_search_type_spellings_rank_when_unordered(self):
+        """With no ordering_key anywhere, search's own type labels
+        still have to identify the majority."""
+        results = [
+            {
+                "opinions": [
+                    {"id": 10, "type": "dissent", "ordering_key": None},
+                    {"id": 11, "type": "lead-opinion", "ordering_key": None},
+                ]
+            }
+        ]
+        add_opinion_ids(results)
+        assert results[0]["opinion_id"] == 11
+
+    def test_leaves_results_without_opinions_untouched(self):
+        results = [{"docket_id": 1}, {"opinions": []}, {"opinions": None}]
+        add_opinion_ids(results)
+        assert all("opinion_id" not in r for r in results)
+
+    def test_does_not_clobber_existing_opinion_id(self):
+        results = [{"opinion_id": 1, "opinions": [{"id": 2}]}]
+        add_opinion_ids(results)
+        assert results[0]["opinion_id"] == 1
+
+    def test_search_tool_adds_id_and_fields_filtering_keeps_it(self):
+        """The added id must survive `fields` — the recommended usage."""
+        tool = SearchTool()
+        client = make_client()
+        client.api_token = "test-token"
+        client.search.list.return_value = FakeIterator(
+            [
+                {
+                    "caseName": "NYSA Series Trust v. Dessein",
+                    "cluster_id": 8695893,
+                    "opinions": [{"id": 8678997}],
+                }
+            ]
+        )
+        with patch.object(SearchTool, "get_client", return_value=client):
+            result = run(tool({"type": "o", "fields": ["caseName"]}, None))
+        assert result["results"] == [
+            {
+                "caseName": "NYSA Series Trust v. Dessein",
+                "opinion_id": 8678997,
+            }
+        ]
+        assert "missing_fields" not in result
+
+    def test_get_more_results_adds_opinion_id(self):
+        tool = GetMoreResultsTool()
+        client = make_client()
+        client.api_token = "test-token"
+        run(get_session().store_query("qid12345", {"response": {}}, client))
+        fake = FakeIterator([{"cluster_id": 1, "opinions": [{"id": 42}]}])
+        fake._page_result_index = 0  # unconsumed results remain
+        with (
+            patch.object(
+                GetMoreResultsTool, "get_client", return_value=client
+            ),
+            patch(
+                "courtlistener.mcp.tools.get_more_results_tool."
+                "ResourceIterator"
+            ) as iterator_cls,
+        ):
+            iterator_cls.load.return_value = fake
+            result = run(tool({"query_id": "qid12345"}, None))
+        assert result["results"][0]["opinion_id"] == 42
+
+
+class TestResolveClusterOpinionIds:
+    def test_returns_the_cluster_s_opinion_ids(self):
+        client = make_client(cluster_opinions={8695893: [8678997, 8678998]})
+        assert resolve_cluster_opinion_ids(8695893, client) == [
+            8678997,
+            8678998,
+        ]
+
+    def test_empty_cluster_raises(self):
+        client = make_client(cluster_opinions={})
+        with pytest.raises(ValueError, match="no opinions"):
+            resolve_cluster_opinion_ids(123, client)
+
+    def test_ordering_key_decides(self):
+        """Citizens United (cluster 1741) as the API really returns it:
+        highest ordering_key first, so the last partial dissent leads
+        and the legacy combined opinion carries no key at all."""
+        client = make_client(
+            cluster_opinions={
+                1741: [
+                    {
+                        "id": 9413191,
+                        "type": "035concurrenceinpart",
+                        "ordering_key": 5,
+                    },
+                    {
+                        "id": 9413190,
+                        "type": "035concurrenceinpart",
+                        "ordering_key": 4,
+                    },
+                    {
+                        "id": 9413189,
+                        "type": "030concurrence",
+                        "ordering_key": 3,
+                    },
+                    {
+                        "id": 9413188,
+                        "type": "030concurrence",
+                        "ordering_key": 2,
+                    },
+                    {"id": 9413187, "type": "020lead", "ordering_key": 1},
+                    {"id": 1741, "type": "010combined", "ordering_key": None},
+                ]
+            }
+        )
+        assert resolve_cluster_opinion_ids(1741, client) == [
+            9413187,  # Kennedy's majority, ordering_key 1
+            9413188,
+            9413189,
+            9413190,
+            9413191,
+            1741,  # no ordering_key, so last
+        ]
+
+    def test_type_breaks_ties_when_ordering_key_is_absent(self):
+        """Older imported clusters carry no ordering_key at all."""
+        client = make_client(
+            cluster_opinions={
+                5: [
+                    {"id": 10, "type": "040dissent", "ordering_key": None},
+                    {"id": 11, "type": "030concurrence", "ordering_key": None},
+                    {"id": 12, "type": "020lead", "ordering_key": None},
+                ]
+            }
+        )
+        assert resolve_cluster_opinion_ids(5, client)[0] == 12
+
+    def test_untyped_opinions_keep_a_stable_order(self):
+        client = make_client(cluster_opinions={5: [12, 10, 11]})
+        assert resolve_cluster_opinion_ids(5, client) == [10, 11, 12]
+
+    def test_requests_only_the_fields_it_sorts_on(self):
+        client = make_client(cluster_opinions={5: [10]})
+        resolve_cluster_opinion_ids(5, client)
+        client.opinions.list.assert_called_once_with(
+            cluster=5, fields=["id", "type", "ordering_key"]
+        )
+
+
+class TestReadDocumentClusterId:
+    def test_cluster_id_resolves_to_the_main_opinion(self):
+        tool = ReadDocumentTool()
+        client = make_client(
+            opinion_texts={8678997: "securities text"},
+            cluster_opinions={8695893: [8678997, 9000001]},
+        )
+        with patch.object(ReadDocumentTool, "get_client", return_value=client):
+            result = run(tool({"cluster_id": 8695893}, None))
+        assert result["doc_id"] == 8678997
+        assert result["sibling_opinion_ids"] == [9000001]
+        assert result["text"] == "securities text"
+
+    def test_rejects_multiple_id_kinds(self):
+        with pytest.raises(ValueError, match="exactly one"):
+            run(ReadDocumentTool()({"opinion_id": 1, "cluster_id": 2}, None))
+
+    def test_schema_accepts_cluster_id(self):
+        MCP_TOOLS["read_document"].validate_arguments({"cluster_id": 123})
+
+    def test_fetch_failure_in_cluster_mode_keeps_siblings(self):
+        tool = ReadDocumentTool()
+        client = make_client(cluster_opinions={5: [10, 11]})
+        client.opinions.get.side_effect = RuntimeError("HTTP 404: not found")
+        with patch.object(ReadDocumentTool, "get_client", return_value=client):
+            result = run(tool({"cluster_id": 5}, None))
+        assert result["doc_id"] == 10
+        assert result["error"] == "HTTP 404: not found"
+        assert result["sibling_opinion_ids"] == [11]
+
+
+class TestSearchDocumentClusterId:
+    def test_searches_only_the_main_opinion(self):
+        """One cluster costs one search, not one per opinion — a
+        fan-out would exhaust a free-tier rate limit in a single call
+        and has no way to resume."""
+        tool = SearchDocumentTool()
+        client = make_client(
+            opinion_texts={10: "alpha beta", 11: "gamma alpha"},
+            cluster_opinions={5: [10, 11]},
+        )
+        with patch.object(
+            SearchDocumentTool, "get_client", return_value=client
+        ):
+            result = run(tool({"cluster_id": 5, "query": "alpha"}, None))
+        assert result["doc_id"] == 10
+        assert result["match_count"] == 1
+        assert result["sibling_opinion_ids"] == [11]
+        assert "results" not in result  # single result, not a list
+
+    def test_single_opinion_cluster_reports_no_siblings(self):
+        tool = SearchDocumentTool()
+        client = make_client(
+            opinion_texts={10: "alpha"},
+            cluster_opinions={5: [10]},
+        )
+        with patch.object(
+            SearchDocumentTool, "get_client", return_value=client
+        ):
+            result = run(tool({"cluster_id": 5, "query": "alpha"}, None))
+        assert result["doc_id"] == 10
+        assert "sibling_opinion_ids" not in result
+
+    def test_empty_cluster_raises(self):
+        tool = SearchDocumentTool()
+        client = make_client(cluster_opinions={})
+        with (
+            patch.object(
+                SearchDocumentTool, "get_client", return_value=client
+            ),
+            pytest.raises(ValueError, match="no opinions"),
+        ):
+            run(tool({"cluster_id": 7, "query": "x"}, None))
+
+    def test_schema_accepts_cluster_id(self):
+        MCP_TOOLS["search_document"].validate_arguments(
+            {"cluster_id": 1, "query": "x"}
+        )
+
+    def test_schema_rejects_cluster_id_list(self):
+        """Multiple documents go through opinion_id, which is bounded."""
+        with pytest.raises(ToolError):
+            MCP_TOOLS["search_document"].validate_arguments(
+                {"cluster_id": [1, 2], "query": "x"}
+            )
+
+    def test_opinion_id_list_still_searches_each(self):
+        tool = SearchDocumentTool()
+        client = make_client(opinion_texts={10: "alpha", 11: "alpha"})
+        with patch.object(
+            SearchDocumentTool, "get_client", return_value=client
+        ):
+            result = run(
+                tool({"opinion_id": [10, 11], "query": "alpha"}, None)
+            )
+        assert [r["doc_id"] for r in result["results"]] == [10, 11]
+
+    def test_rejects_multiple_id_kinds(self):
+        with pytest.raises(ValueError, match="exactly one"):
+            run(
+                SearchDocumentTool()(
+                    {"opinion_id": 1, "cluster_id": 2, "query": "x"}, None
+                )
+            )
+
+
+class TestAnalyzeCitationsClusterId:
+    def test_no_text_error_mentions_cluster_id(self):
+        tool = AnalyzeCitationsTool()
+        client = make_client()  # no opinion_texts: html_with_citations empty
+        with (
+            patch.object(
+                AnalyzeCitationsTool, "get_client", return_value=client
+            ),
+            pytest.raises(ValueError, match="cluster_id"),
+        ):
+            run(tool({"opinion_id": 1}, None))
+
+    def test_schema_accepts_cluster_id(self):
+        MCP_TOOLS["analyze_citations"].validate_arguments({"cluster_id": 123})
+
+    def test_rejects_multiple_id_kinds(self):
+        with pytest.raises(ValueError, match="exactly one"):
+            run(
+                AnalyzeCitationsTool()(
+                    {"opinion_id": 1, "cluster_id": 2}, None
+                )
+            )
+
+    def test_cluster_id_analyzes_the_main_opinion(self):
+        """A cluster id must reach the cluster's opinion, not the
+        unrelated opinion that happens to share the integer."""
+        tool = AnalyzeCitationsTool()
+        client = make_client(
+            opinion_texts={10: "no citations here"},
+            cluster_opinions={5: [10, 11]},
+        )
+        with patch.object(
+            AnalyzeCitationsTool, "get_client", return_value=client
+        ):
+            output = run(tool({"cluster_id": 5}, None))
+        client.opinions.get.assert_called_once_with(10)
+        assert "the main opinion of 2 in cluster 5" in output
+        assert "[11]" in output
+        assert "No citations found." in output
+
+    def test_single_opinion_cluster_adds_no_note(self):
+        tool = AnalyzeCitationsTool()
+        client = make_client(
+            opinion_texts={10: "no citations here"},
+            cluster_opinions={5: [10]},
+        )
+        with patch.object(
+            AnalyzeCitationsTool, "get_client", return_value=client
+        ):
+            output = run(tool({"cluster_id": 5}, None))
+        assert output == "No citations found."
+
+    def test_empty_cluster_raises(self):
+        tool = AnalyzeCitationsTool()
+        client = make_client(cluster_opinions={})
+        with (
+            patch.object(
+                AnalyzeCitationsTool, "get_client", return_value=client
+            ),
+            pytest.raises(ValueError, match="no opinions"),
+        ):
+            run(tool({"cluster_id": 5}, None))

--- a/tests/test_mcp_document_ids.py
+++ b/tests/test_mcp_document_ids.py
@@ -421,7 +421,7 @@ class TestAnalyzeCitationsClusterId:
             output = run(tool({"cluster_id": 5}, None))
         client.opinions.get.assert_called_once_with(10)
         assert "the main opinion of 2 in cluster 5" in output
-        assert "[11]" in output
+        assert "opinion_id: 11" in output
         assert "No citations found." in output
 
     def test_single_opinion_cluster_adds_no_note(self):


### PR DESCRIPTION
Fixes #208

- Updates global prompt to distinguish cluster from opinion ids
- Injects a top level opinion id field on search results that is exempt from field filters
- Adds cluster_id support as input args for search document, read document, and analyze citations.