### PR TITLE
Add support for related fields that don't have a schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ The following changes are not yet released, but are code complete:
 Features:
 - Add support for cluster_id in search_document, read_document, and analyze_citations tools.
 - Add support for space or comma-separated values for multiple-choice fields.
+- Add support for related fields that don't have a schema.
 
 Changes:
 - Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.

--- a/courtlistener/utils.py
+++ b/courtlistener/utils.py
@@ -117,7 +117,13 @@ def related_validator(
     model = get_endpoint_model_from_info(info)
     field = model.model_fields[str(info.field_name)]
     extra = getattr(field, "json_schema_extra", None) or {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Invalid value '{value}' for {info.field_name}")
+    value = {k: v for k, v in value.items() if v is not None}
     related_class_name = extra.get("related_class_name", None)
+    if related_class_name is None:
+        # Return raw value if there isn't a schema for the related field.
+        return value
     related_model = None
     for model in ENDPOINTS.values():
         if model.__name__ == related_class_name:
@@ -125,9 +131,6 @@ def related_validator(
             break
     if related_model is None:
         raise ValueError(f"Related model for {info.field_name} not found")
-    if not isinstance(value, dict):
-        raise ValueError(f"Invalid value '{value}' for {info.field_name}")
-    value = {k: v for k, v in value.items() if v is not None}
     return related_model.model_validate(value).model_dump(by_alias=True)
 
 

--- a/scripts/generate_models.py
+++ b/scripts/generate_models.py
@@ -556,12 +556,9 @@ def get_related_endpoint_id(
         related_endpoint_id = (
             lookup_types.split("'")[1].replace(" ", "-").lower()
         )
-        related_endpoint_id = RELATED_ENDPOINT_MAP.get(
+        return RELATED_ENDPOINT_MAP.get(
             related_endpoint_id, related_endpoint_id
         )
-        if related_endpoint_id is None:
-            print(f"Related endpoint {related_endpoint_id} not found")
-        return related_endpoint_id
     return None
 
 
@@ -768,6 +765,13 @@ def get_endpoint_data(use_cache: bool = True) -> dict[str, Any]:
                 related_endpoint = endpoints.get(
                     endpoint_field["related_endpoint_id"], {}
                 )
+                if not related_endpoint:
+                    print(
+                        f"PASSTHROUGH: {endpoint['id']}."
+                        f"{endpoint_field['id']} relates to "
+                        f"'{endpoint_field['related_endpoint_id']}', "
+                        "which has no standalone endpoint"
+                    )
                 related_id_field = related_endpoint.get("fields", {}).get(
                     "id", {}
                 )

--- a/tests/test_choice_validators.py
+++ b/tests/test_choice_validators.py
@@ -151,13 +151,36 @@ class TestIntChoiceFields:
             self.prayers_status(status="99")
 
 
-def test_related_field_without_schema_extra_raises_cleanly():
-    """Sentry MCP-1J: FieldInfo.json_schema_extra defaults to None (the
-    attribute always exists, so a getattr default never applies). A
-    related-field filter on a field with no configured related model
-    must raise a ValidationError, not AttributeError.
+class TestRelatedPassthrough:
+    """Sentry MCP-1J: related filters whose target has no standalone
+    endpoint (clusters.citations -> Citation) crashed with
+    AttributeError because FieldInfo.json_schema_extra defaults to None
+    (the attribute always exists, so a getattr default never applies).
+    Such fields now pass the sub-filter dict through unvalidated; the
+    API validates server-side.
     """
-    from courtlistener.models.endpoints.clusters import ClustersEndpoint
 
-    with pytest.raises(ValidationError):
-        ClustersEndpoint(citations={"page": "60", "volume": "662"})
+    def test_citations_dict_passes_through(self):
+        from courtlistener.models.endpoints.clusters import ClustersEndpoint
+
+        model = ClustersEndpoint(citations={"page": "60", "volume": "662"})
+        assert model.citations == {"page": "60", "volume": "662"}
+
+    def test_none_subfilters_dropped(self):
+        from courtlistener.models.endpoints.clusters import ClustersEndpoint
+
+        model = ClustersEndpoint(citations={"volume": "662", "page": None})
+        assert model.citations == {"volume": "662"}
+
+    def test_non_dict_still_rejected(self):
+        from courtlistener.models.endpoints.clusters import ClustersEndpoint
+
+        with pytest.raises(ValidationError, match="citations"):
+            ClustersEndpoint(citations=[1, 2])
+
+    def test_validated_related_field_still_validates(self):
+        from courtlistener.models.endpoints.clusters import ClustersEndpoint
+
+        # docket resolves to DocketsEndpoint and must keep validating.
+        with pytest.raises(ValidationError):
+            ClustersEndpoint(docket={"not_a_real_docket_field": 1})


### PR DESCRIPTION
Currently only applies to `citations` field on the `clusters` endpoint.

When models have a `RelatedFilter` we use the schema for the related endpoint to validate the related filter query. However citations doesn't have a dedicated endpoint, so we don't have a schema for it and therefor reject any queries that include it. This adds a fallback for such scenarios. When we don't have a schema for a related field, we just allow the user's raw dict to pass through. 

This slightly deviates from what has been our stance of strict client-side validation. But since CL API now validates and rejects bad queries server side, it should be fine. 

The alternative would be to handwrite a schema for valid citation queries, but this would deviate from our existing pattern of generating all schemas from http options and wouldn't be future-proof when this happens for another field in the future.