### PR TITLE
feat(api): Add near-miss suggestions to invalid-choice errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Features:
 - Add support for cluster_id in search_document, read_document, and analyze_citations tools.
 - Add support for space or comma-separated values for multiple-choice fields.
 - Add support for related fields that don't have a schema.
+- Add near-miss suggestions to invalid-choice errors.
 
 Changes:
 - Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.

--- a/courtlistener/utils.py
+++ b/courtlistener/utils.py
@@ -13,12 +13,15 @@ if TYPE_CHECKING:
 
 def did_you_mean(value: Any, choices: Iterable[Any]) -> str:
     """Suggest near-miss matches for value from choices."""
+    originals: dict[str, str] = {}
+    for choice in choices:
+        originals.setdefault(str(choice).casefold(), str(choice))
     matches = difflib.get_close_matches(
-        str(value), [str(choice) for choice in choices], n=3, cutoff=0.6
+        str(value).casefold(), list(originals), n=3, cutoff=0.6
     )
     if not matches:
         return ""
-    return f" Did you mean: {', '.join(matches)}?"
+    return f" Did you mean: {', '.join(originals[m] for m in matches)}?"
 
 
 def flatten_filters(
@@ -214,16 +217,17 @@ def multiple_choice_validator(
             if isinstance(cleaned, str)
             else []
         )
-        if len(tokens) > 1:
-            token_values = [get_valid_choice(t, choice_dict) for t in tokens]
-            if all(v is not None for v in token_values):
-                valid_values.extend(token_values)  # type: ignore[arg-type]
-                continue
-        invalid_parts = [
-            t
-            for t in (tokens or [cleaned])
-            if get_valid_choice(t, choice_dict) is None
-        ]
+        token_values = [get_valid_choice(t, choice_dict) for t in tokens]
+        if len(tokens) > 1 and all(v is not None for v in token_values):
+            valid_values.extend(token_values)  # type: ignore[arg-type]
+            continue
+        # Suggest per token only when some token is independently valid
+        if len(tokens) > 1 and any(v is not None for v in token_values):
+            invalid_parts = [
+                t for t, v in zip(tokens, token_values) if v is None
+            ]
+        else:
+            invalid_parts = [cleaned]
         raise invalid_choice_error(
             info.field_name, value, invalid_parts, choice_dict
         )

--- a/courtlistener/utils.py
+++ b/courtlistener/utils.py
@@ -166,6 +166,23 @@ def get_valid_choice(
     return None
 
 
+def invalid_choice_error(
+    field_name: str | None,
+    value: Any,
+    invalid_parts: list[Any],
+    choice_dict: dict[str, str] | dict[int, str],
+) -> ValueError:
+    """Build a compact invalid-choice error with near-miss suggestions."""
+    candidates = list(choice_dict) + list(choice_dict.values())
+    suggestions = "".join(
+        did_you_mean(part, candidates) for part in invalid_parts
+    )
+    return ValueError(
+        f"Invalid value '{value}' for {field_name}.{suggestions} "
+        "MCP clients can use the `get_choices` tool to list valid values."
+    )
+
+
 def choice_validator(value: Any, info: ValidationInfo) -> None | int | str:
     if value is None:
         return None
@@ -173,7 +190,7 @@ def choice_validator(value: Any, info: ValidationInfo) -> None | int | str:
     valid_value = get_valid_choice(value, choice_dict)
     if valid_value is not None:
         return valid_value
-    raise ValueError(f"{info.field_name} must be one of {choice_dict}")
+    raise invalid_choice_error(info.field_name, value, [value], choice_dict)
 
 
 def multiple_choice_validator(
@@ -202,8 +219,13 @@ def multiple_choice_validator(
             if all(v is not None for v in token_values):
                 valid_values.extend(token_values)  # type: ignore[arg-type]
                 continue
-        raise ValueError(
-            f"Invalid value '{value}' for {info.field_name}. Must be in {choice_dict}"
+        invalid_parts = [
+            t
+            for t in (tokens or [cleaned])
+            if get_valid_choice(t, choice_dict) is None
+        ]
+        raise invalid_choice_error(
+            info.field_name, value, invalid_parts, choice_dict
         )
     return valid_values[0] if len(valid_values) == 1 else valid_values
 

--- a/tests/test_choice_validators.py
+++ b/tests/test_choice_validators.py
@@ -236,3 +236,34 @@ class TestDidYouMeanErrors:
         msg = str(exc_info.value)
         assert "Did you mean" in msg or "get_choices" in msg
         assert len(msg) < 600
+
+
+class TestSuggestionQuality:
+    """Review nits on PR 228: case-only mismatches must still get
+    suggestions, and multi-word typos must be matched whole rather
+    than split into per-word suggestion noise.
+    """
+
+    def error_for(self, court):
+        with pytest.raises(ValidationError) as exc_info:
+            court_of(court=court)
+        return str(exc_info.value)
+
+    def test_case_only_mismatch_gets_suggestion(self):
+        msg = self.error_for("SCOTUS")
+        assert "scotus" in msg
+
+    def test_multiword_typo_matched_whole(self):
+        msg = self.error_for("Supreme Court")
+        # Whole-string matches, not per-word fragments.
+        assert "Supreme Court" in msg.split("Did you mean")[1]
+        assert "prsupreme" not in msg
+        assert "ortc" not in msg
+
+    def test_comma_containing_typo_matched_whole(self):
+        msg = self.error_for("District Court, D. Nonexistent")
+        assert "District Court, D." in msg.split("Did you mean")[1]
+
+    def test_genuine_list_still_suggests_per_token(self):
+        msg = self.error_for("scotus texapp2")
+        assert "texapp" in msg

--- a/tests/test_choice_validators.py
+++ b/tests/test_choice_validators.py
@@ -184,3 +184,55 @@ class TestRelatedPassthrough:
         # docket resolves to DocketsEndpoint and must keep validating.
         with pytest.raises(ValidationError):
             ClustersEndpoint(docket={"not_a_real_docket_field": 1})
+
+
+class TestDidYouMeanErrors:
+    """Invalid-choice errors suggest near misses instead of dumping the
+    full choice dict (court alone is 470 entries / ~10k chars). The bad
+    ids here are the most common model hallucinations from Sentry MCP-G.
+    """
+
+    def error_for(self, court):
+        with pytest.raises(ValidationError) as exc_info:
+            court_of(court=court)
+        return str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "bad,expected_suggestion",
+        [
+            ("njsupct", "nysupct"),
+            ("texapp2", "texapp"),
+            ("fladistctapp1", "fladistctapp"),
+            ("ganctapp", "gactapp"),
+            ("okno", "oknd"),
+        ],
+    )
+    def test_hallucinated_ids_get_suggestions(self, bad, expected_suggestion):
+        msg = self.error_for(bad)
+        assert "Did you mean" in msg
+        assert expected_suggestion in msg
+
+    def test_choice_dict_not_dumped(self):
+        msg = self.error_for("njsupct")
+        assert "Supreme Court of the United States" not in msg
+        assert len(msg) < 600
+
+    def test_mixed_tokens_suggest_only_invalid(self):
+        # 'scotus' is valid; suggestions should target 'texapp2' only.
+        msg = self.error_for("scotus texapp2")
+        assert "texapp" in msg
+        assert "Did you mean" in msg
+
+    def test_points_to_get_choices(self):
+        assert "get_choices" in self.error_for("njsupct")
+
+    def test_single_choice_field_also_compact(self):
+        from courtlistener.models.endpoints.opinion_search import (
+            OpinionSearchEndpoint,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            OpinionSearchEndpoint(type="o", order_by="relevance desc")
+        msg = str(exc_info.value)
+        assert "Did you mean" in msg or "get_choices" in msg
+        assert len(msg) < 600


### PR DESCRIPTION
When an MCP client hallucinates a bad value for a choice or multi-choice field. We currently dump the full list of choices. This can be a brutal amount of tokens for fields with many choices (e.g. courts). Instead use our did_you_mean helper to just dump the top suggestions and direct the client to use the `get_choices` tool if they want the full list.