### PR TITLE
feat(mcp): Better response when `get_choices` used on a non-choice field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Features:
 - Add support for space or comma-separated values for multiple-choice fields.
 - Add support for related fields that don't have a schema.
 - Add near-miss suggestions to invalid-choice errors.
+- Better response when a model uses `get_choices` tool on a non-choice field.
 
 Changes:
 - Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.

--- a/courtlistener/mcp/tools/get_choices_tool.py
+++ b/courtlistener/mcp/tools/get_choices_tool.py
@@ -1,3 +1,5 @@
+from typing import Literal, get_args, get_origin
+
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
@@ -58,10 +60,50 @@ class GetChoicesTool(MCPTool):
 
             extra = getattr(field_info, "json_schema_extra", {}) or {}
             choices = extra.get("choices", [])
+            if not choices and get_origin(field_info.annotation) is Literal:
+                # If literal, provide the fixed values
+                values = get_args(field_info.annotation)
+                return {
+                    "choices": [
+                        {"value": v, "display_name": str(v)} for v in values
+                    ],
+                    "note": (
+                        f"Field '{field_name}' is fixed to "
+                        f"{', '.join(repr(v) for v in values)} on endpoint "
+                        f"'{endpoint_id}'; there is nothing to choose."
+                    ),
+                }
             if not choices:
-                raise ValueError(
-                    f"Field '{field_name}' on endpoint '{endpoint_id}' has no choices"
+                if extra.get("related_class_name"):
+                    # If a related field, explain to use id or related query
+                    note = (
+                        f"Field '{field_name}' on endpoint "
+                        f"'{endpoint_id}' is a related-object filter, "
+                        "not a choice field: pass the related record's "
+                        f"id (e.g. {field_name}='scotus' for courts) "
+                        "or a dict of its subfields."
+                    )
+                else:
+                    # If a free-text field, explain
+                    note = (
+                        f"Field '{field_name}' on endpoint "
+                        f"'{endpoint_id}' has no fixed choice list; it "
+                        "accepts free-form values."
+                    )
+                # Provide a list of which fields do have choices
+                choice_fields = sorted(
+                    name
+                    for name, f in endpoint.model_fields.items()
+                    if (getattr(f, "json_schema_extra", None) or {}).get(
+                        "choices"
+                    )
                 )
+                if choice_fields:
+                    note += (
+                        f" Fields on '{endpoint_id}' that do have "
+                        f"choices: {', '.join(choice_fields)}."
+                    )
+                return {"choices": [], "note": note}
 
             return {"choices": choices}
 

--- a/courtlistener/mcp/tools/get_choices_tool.py
+++ b/courtlistener/mcp/tools/get_choices_tool.py
@@ -9,6 +9,26 @@ from courtlistener.models import ENDPOINTS
 from courtlistener.utils import did_you_mean
 
 
+def related_example(
+    field_name: str, field_info, related_class_name: str
+) -> tuple[str, str]:
+    """Return ``(related_endpoint_id, example)`` for a related filter."""
+    related_id = related_class_name
+    for endpoint in ENDPOINTS.values():
+        if endpoint.__name__ == related_class_name:
+            related_id = endpoint.endpoint_id
+            break
+
+    id_types = get_args(field_info.annotation)
+    if related_id == "courts":
+        example = f"{field_name}='scotus'"
+    elif str in id_types:
+        example = f"{field_name}='some-id'"
+    else:
+        example = f"{field_name}=12345"
+    return related_id, example
+
+
 class GetChoicesTool(MCPTool):
     """Get the valid choices for a field on a CourtListener API endpoint.
 
@@ -42,7 +62,7 @@ class GetChoicesTool(MCPTool):
 
     async def __call__(
         self, arguments: dict, ctx: Context
-    ) -> dict[str, list[dict]]:
+    ) -> dict[str, list[dict] | str]:
         endpoint_id: str = arguments["endpoint_id"]
         field_name: str = arguments["field_name"]
 
@@ -76,12 +96,15 @@ class GetChoicesTool(MCPTool):
             if not choices:
                 if extra.get("related_class_name"):
                     # If a related field, explain to use id or related query
+                    related_id, example = related_example(
+                        field_name, field_info, extra["related_class_name"]
+                    )
                     note = (
                         f"Field '{field_name}' on endpoint "
                         f"'{endpoint_id}' is a related-object filter, "
-                        "not a choice field: pass the related record's "
-                        f"id (e.g. {field_name}='scotus' for courts) "
-                        "or a dict of its subfields."
+                        f"not a choice field: pass a {related_id} "
+                        f"record's id (e.g. {example}) or a dict of "
+                        f"{related_id} subfields."
                     )
                 else:
                     # If a free-text field, explain

--- a/courtlistener/models/endpoints/attorneys.py
+++ b/courtlistener/models/endpoints/attorneys.py
@@ -87,6 +87,7 @@ class AttorneysEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a dockets record\u0027s id, or a dict of dockets sub-filters (sent as docket__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketsEndpoint",
             },
@@ -97,6 +98,7 @@ class AttorneysEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a parties record\u0027s id, or a dict of parties sub-filters (sent as parties_represented__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PartiesEndpoint",
             },

--- a/courtlistener/models/endpoints/audio.py
+++ b/courtlistener/models/endpoints/audio.py
@@ -171,6 +171,7 @@ class AudioEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a dockets record\u0027s id, or a dict of dockets sub-filters (sent as docket__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketsEndpoint",
             },

--- a/courtlistener/models/endpoints/clusters.py
+++ b/courtlistener/models/endpoints/clusters.py
@@ -253,6 +253,7 @@ class ClustersEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a dockets record\u0027s id, or a dict of dockets sub-filters (sent as docket__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketsEndpoint",
             },
@@ -263,6 +264,7 @@ class ClustersEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a people record\u0027s id, or a dict of people sub-filters (sent as panel__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PeopleEndpoint",
             },
@@ -273,6 +275,7 @@ class ClustersEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a people record\u0027s id, or a dict of people sub-filters (sent as non_participating_judges__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PeopleEndpoint",
             },
@@ -283,6 +286,7 @@ class ClustersEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a opinions record\u0027s id, or a dict of opinions sub-filters (sent as sub_opinions__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "OpinionsEndpoint",
             },

--- a/courtlistener/models/endpoints/courts.py
+++ b/courtlistener/models/endpoints/courts.py
@@ -165,6 +165,7 @@ class CourtsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a dockets record\u0027s id, or a dict of dockets sub-filters (sent as dockets__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketsEndpoint",
             },

--- a/courtlistener/models/endpoints/docket_entries.py
+++ b/courtlistener/models/endpoints/docket_entries.py
@@ -110,6 +110,7 @@ class DocketEntriesEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a dockets record\u0027s id, or a dict of dockets sub-filters (sent as docket__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketsEndpoint",
             },
@@ -120,6 +121,7 @@ class DocketEntriesEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a recap-documents record\u0027s id, or a dict of recap-documents sub-filters (sent as recap_documents__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "RecapDocumentsEndpoint",
             },

--- a/courtlistener/models/endpoints/docket_tags.py
+++ b/courtlistener/models/endpoints/docket_tags.py
@@ -56,6 +56,7 @@ class DocketTagsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a tags record\u0027s id, or a dict of tags sub-filters (sent as tag__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "TagsEndpoint",
             },

--- a/courtlistener/models/endpoints/dockets.py
+++ b/courtlistener/models/endpoints/dockets.py
@@ -1255,6 +1255,7 @@ class DocketsEndpoint(Endpoint):
         None | dict[str, Any] | str,
         Field(
             None,
+            description="Related filter: pass a courts record\u0027s id, or a dict of courts sub-filters (sent as court__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "CourtsEndpoint",
             },
@@ -1265,6 +1266,7 @@ class DocketsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a clusters record\u0027s id, or a dict of clusters sub-filters (sent as clusters__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "ClustersEndpoint",
             },
@@ -1275,6 +1277,7 @@ class DocketsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a docket-entries record\u0027s id, or a dict of docket-entries sub-filters (sent as docket_entries__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketEntriesEndpoint",
             },
@@ -1285,6 +1288,7 @@ class DocketsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a audio record\u0027s id, or a dict of audio sub-filters (sent as audio_files__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "AudioEndpoint",
             },
@@ -1295,6 +1299,7 @@ class DocketsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a people record\u0027s id, or a dict of people sub-filters (sent as assigned_to__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PeopleEndpoint",
             },
@@ -1305,6 +1310,7 @@ class DocketsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a people record\u0027s id, or a dict of people sub-filters (sent as referred_to__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PeopleEndpoint",
             },
@@ -1315,6 +1321,7 @@ class DocketsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a parties record\u0027s id, or a dict of parties sub-filters (sent as parties__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PartiesEndpoint",
             },

--- a/courtlistener/models/endpoints/educations.py
+++ b/courtlistener/models/endpoints/educations.py
@@ -129,6 +129,7 @@ class EducationsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a people record\u0027s id, or a dict of people sub-filters (sent as person__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PeopleEndpoint",
             },
@@ -139,6 +140,7 @@ class EducationsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a schools record\u0027s id, or a dict of schools sub-filters (sent as school__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "SchoolsEndpoint",
             },

--- a/courtlistener/models/endpoints/financial_disclosures.py
+++ b/courtlistener/models/endpoints/financial_disclosures.py
@@ -98,6 +98,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a people record\u0027s id, or a dict of people sub-filters (sent as person__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PeopleEndpoint",
             },
@@ -136,6 +137,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a agreements record\u0027s id, or a dict of agreements sub-filters (sent as agreements__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "AgreementsEndpoint",
             },
@@ -146,6 +148,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a debts record\u0027s id, or a dict of debts sub-filters (sent as debts__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DebtsEndpoint",
             },
@@ -156,6 +159,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a gifts record\u0027s id, or a dict of gifts sub-filters (sent as gifts__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "GiftsEndpoint",
             },
@@ -166,6 +170,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a investments record\u0027s id, or a dict of investments sub-filters (sent as investments__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "InvestmentsEndpoint",
             },
@@ -176,6 +181,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a non-investment-incomes record\u0027s id, or a dict of non-investment-incomes sub-filters (sent as non_investment_incomes__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "NonInvestmentIncomesEndpoint",
             },
@@ -186,6 +192,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a positions record\u0027s id, or a dict of positions sub-filters (sent as positions__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PositionsEndpoint",
             },
@@ -196,6 +203,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a reimbursements record\u0027s id, or a dict of reimbursements sub-filters (sent as reimbursements__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "ReimbursementsEndpoint",
             },
@@ -206,6 +214,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a spouse-incomes record\u0027s id, or a dict of spouse-incomes sub-filters (sent as spouse_incomes__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "SpouseIncomesEndpoint",
             },

--- a/courtlistener/models/endpoints/opinions.py
+++ b/courtlistener/models/endpoints/opinions.py
@@ -136,6 +136,7 @@ class OpinionsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a clusters record\u0027s id, or a dict of clusters sub-filters (sent as cluster__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "ClustersEndpoint",
             },
@@ -146,6 +147,7 @@ class OpinionsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a people record\u0027s id, or a dict of people sub-filters (sent as author__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PeopleEndpoint",
             },
@@ -156,6 +158,7 @@ class OpinionsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a people record\u0027s id, or a dict of people sub-filters (sent as joined_by__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PeopleEndpoint",
             },

--- a/courtlistener/models/endpoints/opinions_cited.py
+++ b/courtlistener/models/endpoints/opinions_cited.py
@@ -58,6 +58,7 @@ class OpinionsCitedEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a opinions record\u0027s id, or a dict of opinions sub-filters (sent as citing_opinion__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "OpinionsEndpoint",
             },
@@ -68,6 +69,7 @@ class OpinionsCitedEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a opinions record\u0027s id, or a dict of opinions sub-filters (sent as cited_opinion__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "OpinionsEndpoint",
             },

--- a/courtlistener/models/endpoints/parties.py
+++ b/courtlistener/models/endpoints/parties.py
@@ -82,6 +82,7 @@ class PartiesEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a dockets record\u0027s id, or a dict of dockets sub-filters (sent as docket__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketsEndpoint",
             },
@@ -92,6 +93,7 @@ class PartiesEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a attorneys record\u0027s id, or a dict of attorneys sub-filters (sent as attorney__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "AttorneysEndpoint",
             },

--- a/courtlistener/models/endpoints/people.py
+++ b/courtlistener/models/endpoints/people.py
@@ -365,6 +365,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a educations record\u0027s id, or a dict of educations sub-filters (sent as educations__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "EducationsEndpoint",
             },
@@ -375,6 +376,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a political-affiliations record\u0027s id, or a dict of political-affiliations sub-filters (sent as political_affiliations__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PoliticalAffiliationsEndpoint",
             },
@@ -385,6 +387,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a sources record\u0027s id, or a dict of sources sub-filters (sent as sources__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "SourcesEndpoint",
             },
@@ -395,6 +398,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a aba-ratings record\u0027s id, or a dict of aba-ratings sub-filters (sent as aba_ratings__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "AbaRatingsEndpoint",
             },
@@ -405,6 +409,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a positions record\u0027s id, or a dict of positions sub-filters (sent as positions__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "PositionsEndpoint",
             },
@@ -415,6 +420,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a clusters record\u0027s id, or a dict of clusters sub-filters (sent as opinion_clusters_participating_judges__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "ClustersEndpoint",
             },
@@ -425,6 +431,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a clusters record\u0027s id, or a dict of clusters sub-filters (sent as opinion_clusters_non_participating_judges__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "ClustersEndpoint",
             },
@@ -435,6 +442,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a opinions record\u0027s id, or a dict of opinions sub-filters (sent as opinions_written__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "OpinionsEndpoint",
             },
@@ -445,6 +453,7 @@ class PeopleEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a opinions record\u0027s id, or a dict of opinions sub-filters (sent as opinions_joined__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "OpinionsEndpoint",
             },

--- a/courtlistener/models/endpoints/positions.py
+++ b/courtlistener/models/endpoints/positions.py
@@ -735,6 +735,7 @@ class PositionsEndpoint(Endpoint):
         None | dict[str, Any] | str,
         Field(
             None,
+            description="Related filter: pass a courts record\u0027s id, or a dict of courts sub-filters (sent as court__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "CourtsEndpoint",
             },
@@ -745,6 +746,7 @@ class PositionsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a retention-events record\u0027s id, or a dict of retention-events sub-filters (sent as retention_events__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "RetentionEventsEndpoint",
             },

--- a/courtlistener/models/endpoints/recap_documents.py
+++ b/courtlistener/models/endpoints/recap_documents.py
@@ -193,6 +193,7 @@ class RecapDocumentsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a docket-entries record\u0027s id, or a dict of docket-entries sub-filters (sent as docket_entry__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketEntriesEndpoint",
             },
@@ -203,6 +204,7 @@ class RecapDocumentsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a tags record\u0027s id, or a dict of tags sub-filters (sent as tags__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "TagsEndpoint",
             },

--- a/courtlistener/models/endpoints/recap_query.py
+++ b/courtlistener/models/endpoints/recap_query.py
@@ -141,6 +141,7 @@ class RecapQueryEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a docket-entries record\u0027s id, or a dict of docket-entries sub-filters (sent as docket_entry__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "DocketEntriesEndpoint",
             },
@@ -151,6 +152,7 @@ class RecapQueryEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a tags record\u0027s id, or a dict of tags sub-filters (sent as tags__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "TagsEndpoint",
             },

--- a/courtlistener/models/endpoints/schools.py
+++ b/courtlistener/models/endpoints/schools.py
@@ -88,6 +88,7 @@ class SchoolsEndpoint(Endpoint):
         None | dict[str, Any] | int,
         Field(
             None,
+            description="Related filter: pass a educations record\u0027s id, or a dict of educations sub-filters (sent as educations__\u003csubfilter\u003e lookups). Not an enumerated choice field.",
             json_schema_extra={
                 "related_class_name": "EducationsEndpoint",
             },

--- a/docs/api/endpoints/attorneys.md
+++ b/docs/api/endpoints/attorneys.md
@@ -68,11 +68,15 @@ Lookups: `iexact`, `istartswith`, `startswith`
 
 integer
 
+Related filter: pass a dockets record's id, or a dict of dockets sub-filters (sent as docket__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`dockets`](./dockets.md)
 
 ### `parties_represented`
 
 integer
+
+Related filter: pass a parties record's id, or a dict of parties sub-filters (sent as parties_represented__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`parties`](./parties.md)
 

--- a/docs/api/endpoints/audio.md
+++ b/docs/api/endpoints/audio.md
@@ -120,6 +120,8 @@ Choices (6):
 
 integer
 
+Related filter: pass a dockets record's id, or a dict of dockets sub-filters (sent as docket__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`dockets`](./dockets.md)
 
 ### `source`

--- a/docs/api/endpoints/clusters.md
+++ b/docs/api/endpoints/clusters.md
@@ -176,11 +176,15 @@ Whether a document should be blocked from indexing by search engines
 
 integer
 
+Related filter: pass a dockets record's id, or a dict of dockets sub-filters (sent as docket__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`dockets`](./dockets.md)
 
 ### `panel`
 
 integer
+
+Related filter: pass a people record's id, or a dict of people sub-filters (sent as panel__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`people`](./people.md)
 
@@ -188,11 +192,15 @@ Related endpoint: [`people`](./people.md)
 
 integer
 
+Related filter: pass a people record's id, or a dict of people sub-filters (sent as non_participating_judges__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`people`](./people.md)
 
 ### `sub_opinions`
 
 integer
+
+Related filter: pass a opinions record's id, or a dict of opinions sub-filters (sent as sub_opinions__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`opinions`](./opinions.md)
 

--- a/docs/api/endpoints/courts.md
+++ b/docs/api/endpoints/courts.md
@@ -129,6 +129,8 @@ Lookups: `iexact`, `istartswith`, `startswith`
 
 integer
 
+Related filter: pass a dockets record's id, or a dict of dockets sub-filters (sent as dockets__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`dockets`](./dockets.md)
 
 ### `jurisdiction`

--- a/docs/api/endpoints/docket_entries.md
+++ b/docs/api/endpoints/docket_entries.md
@@ -89,11 +89,15 @@ Lookups: `gt`, `gte`, `isnull`, `lt`, `lte`, `range`
 
 integer
 
+Related filter: pass a dockets record's id, or a dict of dockets sub-filters (sent as docket__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`dockets`](./dockets.md)
 
 ### `recap_documents`
 
 integer
+
+Related filter: pass a recap-documents record's id, or a dict of recap-documents sub-filters (sent as recap_documents__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`recap_documents`](./recap_documents.md)
 

--- a/docs/api/endpoints/docket_tags.md
+++ b/docs/api/endpoints/docket_tags.md
@@ -41,4 +41,6 @@ integer
 
 integer
 
+Related filter: pass a tags record's id, or a dict of tags sub-filters (sent as tag__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`tags`](./tags.md)

--- a/docs/api/endpoints/dockets.md
+++ b/docs/api/endpoints/dockets.md
@@ -446,11 +446,15 @@ Whether a document should be blocked from indexing by search engines
 
 string
 
+Related filter: pass a courts record's id, or a dict of courts sub-filters (sent as court__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`courts`](./courts.md)
 
 ### `clusters`
 
 integer
+
+Related filter: pass a clusters record's id, or a dict of clusters sub-filters (sent as clusters__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`clusters`](./clusters.md)
 
@@ -458,11 +462,15 @@ Related endpoint: [`clusters`](./clusters.md)
 
 integer
 
+Related filter: pass a docket-entries record's id, or a dict of docket-entries sub-filters (sent as docket_entries__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`docket_entries`](./docket_entries.md)
 
 ### `audio_files`
 
 integer
+
+Related filter: pass a audio record's id, or a dict of audio sub-filters (sent as audio_files__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`audio`](./audio.md)
 
@@ -470,17 +478,23 @@ Related endpoint: [`audio`](./audio.md)
 
 integer
 
+Related filter: pass a people record's id, or a dict of people sub-filters (sent as assigned_to__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`people`](./people.md)
 
 ### `referred_to`
 
 integer
 
+Related filter: pass a people record's id, or a dict of people sub-filters (sent as referred_to__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`people`](./people.md)
 
 ### `parties`
 
 integer
+
+Related filter: pass a parties record's id, or a dict of parties sub-filters (sent as parties__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`parties`](./parties.md)
 

--- a/docs/api/endpoints/educations.md
+++ b/docs/api/endpoints/educations.md
@@ -98,11 +98,15 @@ Normalized degree level, e.g. BA, JD.
 
 integer
 
+Related filter: pass a people record's id, or a dict of people sub-filters (sent as person__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`people`](./people.md)
 
 ### `school`
 
 integer
+
+Related filter: pass a schools record's id, or a dict of schools sub-filters (sent as school__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`schools`](./schools.md)
 

--- a/docs/api/endpoints/financial_disclosures.md
+++ b/docs/api/endpoints/financial_disclosures.md
@@ -60,6 +60,8 @@ integer
 
 integer
 
+Related filter: pass a people record's id, or a dict of people sub-filters (sent as person__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`people`](./people.md)
 
 ### `date_created`
@@ -96,11 +98,15 @@ Have we successfully extracted the data from PDF?
 
 integer
 
+Related filter: pass a agreements record's id, or a dict of agreements sub-filters (sent as agreements__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`agreements`](./agreements.md)
 
 ### `debts`
 
 integer
+
+Related filter: pass a debts record's id, or a dict of debts sub-filters (sent as debts__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`debts`](./debts.md)
 
@@ -108,11 +114,15 @@ Related endpoint: [`debts`](./debts.md)
 
 integer
 
+Related filter: pass a gifts record's id, or a dict of gifts sub-filters (sent as gifts__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`gifts`](./gifts.md)
 
 ### `investments`
 
 integer
+
+Related filter: pass a investments record's id, or a dict of investments sub-filters (sent as investments__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`investments`](./investments.md)
 
@@ -120,11 +130,15 @@ Related endpoint: [`investments`](./investments.md)
 
 integer
 
+Related filter: pass a non-investment-incomes record's id, or a dict of non-investment-incomes sub-filters (sent as non_investment_incomes__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`non_investment_incomes`](./non_investment_incomes.md)
 
 ### `positions`
 
 integer
+
+Related filter: pass a positions record's id, or a dict of positions sub-filters (sent as positions__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`positions`](./positions.md)
 
@@ -132,11 +146,15 @@ Related endpoint: [`positions`](./positions.md)
 
 integer
 
+Related filter: pass a reimbursements record's id, or a dict of reimbursements sub-filters (sent as reimbursements__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`reimbursements`](./reimbursements.md)
 
 ### `spouse_incomes`
 
 integer
+
+Related filter: pass a spouse-incomes record's id, or a dict of spouse-incomes sub-filters (sent as spouse_incomes__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`spouse_incomes`](./spouse_incomes.md)
 

--- a/docs/api/endpoints/opinions.md
+++ b/docs/api/endpoints/opinions.md
@@ -100,17 +100,23 @@ Is this opinion per curiam, without a single author?
 
 integer
 
+Related filter: pass a clusters record's id, or a dict of clusters sub-filters (sent as cluster__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`clusters`](./clusters.md)
 
 ### `author`
 
 integer
 
+Related filter: pass a people record's id, or a dict of people sub-filters (sent as author__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`people`](./people.md)
 
 ### `joined_by`
 
 integer
+
+Related filter: pass a people record's id, or a dict of people sub-filters (sent as joined_by__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`people`](./people.md)
 

--- a/docs/api/endpoints/opinions_cited.md
+++ b/docs/api/endpoints/opinions_cited.md
@@ -39,10 +39,14 @@ integer
 
 integer
 
+Related filter: pass a opinions record's id, or a dict of opinions sub-filters (sent as citing_opinion__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`opinions`](./opinions.md)
 
 ### `cited_opinion`
 
 integer
+
+Related filter: pass a opinions record's id, or a dict of opinions sub-filters (sent as cited_opinion__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`opinions`](./opinions.md)

--- a/docs/api/endpoints/parties.md
+++ b/docs/api/endpoints/parties.md
@@ -66,11 +66,15 @@ Lookups: `iexact`, `istartswith`, `startswith`
 
 integer
 
+Related filter: pass a dockets record's id, or a dict of dockets sub-filters (sent as docket__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`dockets`](./dockets.md)
 
 ### `attorney`
 
 integer
+
+Related filter: pass a attorneys record's id, or a dict of attorneys sub-filters (sent as attorney__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`attorneys`](./attorneys.md)
 

--- a/docs/api/endpoints/people.md
+++ b/docs/api/endpoints/people.md
@@ -338,11 +338,15 @@ Choices (3):
 
 integer
 
+Related filter: pass a educations record's id, or a dict of educations sub-filters (sent as educations__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`educations`](./educations.md)
 
 ### `political_affiliations`
 
 integer
+
+Related filter: pass a political-affiliations record's id, or a dict of political-affiliations sub-filters (sent as political_affiliations__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`political_affiliations`](./political_affiliations.md)
 
@@ -350,11 +354,15 @@ Related endpoint: [`political_affiliations`](./political_affiliations.md)
 
 integer
 
+Related filter: pass a sources record's id, or a dict of sources sub-filters (sent as sources__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`sources`](./sources.md)
 
 ### `aba_ratings`
 
 integer
+
+Related filter: pass a aba-ratings record's id, or a dict of aba-ratings sub-filters (sent as aba_ratings__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`aba_ratings`](./aba_ratings.md)
 
@@ -362,11 +370,15 @@ Related endpoint: [`aba_ratings`](./aba_ratings.md)
 
 integer
 
+Related filter: pass a positions record's id, or a dict of positions sub-filters (sent as positions__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`positions`](./positions.md)
 
 ### `opinion_clusters_participating_judges`
 
 integer
+
+Related filter: pass a clusters record's id, or a dict of clusters sub-filters (sent as opinion_clusters_participating_judges__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`clusters`](./clusters.md)
 
@@ -374,17 +386,23 @@ Related endpoint: [`clusters`](./clusters.md)
 
 integer
 
+Related filter: pass a clusters record's id, or a dict of clusters sub-filters (sent as opinion_clusters_non_participating_judges__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`clusters`](./clusters.md)
 
 ### `opinions_written`
 
 integer
 
+Related filter: pass a opinions record's id, or a dict of opinions sub-filters (sent as opinions_written__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`opinions`](./opinions.md)
 
 ### `opinions_joined`
 
 integer
+
+Related filter: pass a opinions record's id, or a dict of opinions sub-filters (sent as opinions_joined__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`opinions`](./opinions.md)
 

--- a/docs/api/endpoints/positions.md
+++ b/docs/api/endpoints/positions.md
@@ -447,11 +447,15 @@ Lookups: `iexact`, `istartswith`, `startswith`
 
 string
 
+Related filter: pass a courts record's id, or a dict of courts sub-filters (sent as court__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`courts`](./courts.md)
 
 ### `retention_events`
 
 integer
+
+Related filter: pass a retention-events record's id, or a dict of retention-events sub-filters (sent as retention_events__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`retention_events`](./retention_events.md)
 

--- a/docs/api/endpoints/recap_documents.md
+++ b/docs/api/endpoints/recap_documents.md
@@ -146,11 +146,15 @@ Is this item freely available as an opinion on PACER?
 
 integer
 
+Related filter: pass a docket-entries record's id, or a dict of docket-entries sub-filters (sent as docket_entry__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`docket_entries`](./docket_entries.md)
 
 ### `tags`
 
 integer
+
+Related filter: pass a tags record's id, or a dict of tags sub-filters (sent as tags__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`tags`](./tags.md)
 

--- a/docs/api/endpoints/recap_query.md
+++ b/docs/api/endpoints/recap_query.md
@@ -104,10 +104,14 @@ boolean
 
 integer
 
+Related filter: pass a docket-entries record's id, or a dict of docket-entries sub-filters (sent as docket_entry__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`docket_entries`](./docket_entries.md)
 
 ### `tags`
 
 integer
+
+Related filter: pass a tags record's id, or a dict of tags sub-filters (sent as tags__<subfilter> lookups). Not an enumerated choice field.
 
 Related endpoint: [`tags`](./tags.md)

--- a/docs/api/endpoints/schools.md
+++ b/docs/api/endpoints/schools.md
@@ -71,6 +71,8 @@ The EIN assigned by the IRS
 
 integer
 
+Related filter: pass a educations record's id, or a dict of educations sub-filters (sent as educations__<subfilter> lookups). Not an enumerated choice field.
+
 Related endpoint: [`educations`](./educations.md)
 
 ### `order_by`

--- a/scripts/generate_models.py
+++ b/scripts/generate_models.py
@@ -784,6 +784,14 @@ def get_endpoint_data(use_cache: bool = True) -> dict[str, Any]:
                 endpoint_field["related_class_name"] = related_endpoint.get(
                     "class_name"
                 )
+                if related_endpoint and not endpoint_field.get("description"):
+                    related_id = endpoint_field["related_endpoint_id"]
+                    endpoint_field["description"] = (
+                        f"Related filter: pass a {related_id} record's "
+                        f"id, or a dict of {related_id} sub-filters "
+                        f"(sent as {endpoint_field['id']}__<subfilter> "
+                        "lookups). Not an enumerated choice field."
+                    )
 
             if not endpoint_field["types"]:
                 print(

--- a/tests/test_get_choices_tool.py
+++ b/tests/test_get_choices_tool.py
@@ -1,0 +1,68 @@
+"""Behavior tests for the get_choices tool (Sentry MCP-N).
+
+Asking for choices on a field that has none is routine model
+exploration -- ~70% of MCP-N was `nature_of_suit`, which models
+reasonably assume is enumerable (PACER's NOS codes are a fixed
+taxonomy) but CL stores as free text. The tool now answers those
+questions instead of raising, and misnamed fields raise a
+Sentry-exempt error with suggestions.
+"""
+
+import pytest
+
+from courtlistener.mcp.tools import MCP_TOOLS
+
+
+class FakeContext:
+    pass
+
+
+async def call(**arguments):
+    return await MCP_TOOLS["get_choices"](arguments, FakeContext())
+
+
+class TestGetChoices:
+    @pytest.mark.asyncio
+    async def test_field_with_choices(self):
+        result = await call(endpoint_id="search", field_name="court")
+        assert {
+            k: v for k, v in result["choices"][0].items() if k == "value"
+        } == {"value": "scotus"}
+
+    @pytest.mark.asyncio
+    async def test_free_text_field_answers_instead_of_erroring(self):
+        result = await call(endpoint_id="search", field_name="nature_of_suit")
+        assert result["choices"] == []
+        assert "no fixed choice list" in result["note"]
+        assert (
+            "court" in result["note"]
+        )  # points at fields that DO have choices
+
+    @pytest.mark.asyncio
+    async def test_related_field_gets_related_guidance(self):
+        result = await call(endpoint_id="dockets", field_name="court")
+        assert result["choices"] == []
+        assert "related-object filter" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_errors_with_suggestion(self):
+        with pytest.raises(ValueError) as exc_info:
+            await call(
+                endpoint_id="people", field_name="political_affiliation"
+            )
+        assert "political_affiliations" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_literal_field_reports_fixed_value(self):
+        result = await call(endpoint_id="opinion-search", field_name="type")
+        assert result["choices"] == [{"value": "o", "display_name": "o"}]
+        assert "fixed to 'o'" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_related_field_description_generated(self):
+        from courtlistener.models.endpoints.dockets import DocketsEndpoint
+
+        desc = DocketsEndpoint.model_fields["court"].description
+        assert "Related filter" in desc
+        assert "court__" in desc
+        assert "Not an enumerated choice field" in desc

--- a/tests/test_get_choices_tool.py
+++ b/tests/test_get_choices_tool.py
@@ -43,6 +43,16 @@ class TestGetChoices:
         result = await call(endpoint_id="dockets", field_name="court")
         assert result["choices"] == []
         assert "related-object filter" in result["note"]
+        assert "court='scotus'" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_related_example_adapts_to_related_model(self):
+        # assigned_to relates to people (int ids), so the example must
+        # not be the court-specific 'scotus'.
+        result = await call(endpoint_id="dockets", field_name="assigned_to")
+        assert "people record's id" in result["note"]
+        assert "assigned_to=12345" in result["note"]
+        assert "scotus" not in result["note"]
 
     @pytest.mark.asyncio
     async def test_unknown_field_errors_with_suggestion(self):


### PR DESCRIPTION
Sometimes models use `get_choices` to inspect non-choice fields. This is often due to reasonable assumptions e.g. assuming `nature_of_suit` has a predefined set of options rather than being a free text field.

Add better responses for when models make this mistake:
- If the field is a related field, explain that it can use the related model's id or provide a subquery
- If it's free text, explain that.