### PR TITLE
feat(mcp): exempt expected 401s from sentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Changes:
 - Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.
 - Add terms and privacy policy to index.html.
 - Fingerprint validation errors by model and field for Sentry.
+- Exempt routine token rotation errors from Sentry.
 
 Fixes:
 - Handle json_schema_extra when it exists but is None.

--- a/courtlistener/mcp/auth.py
+++ b/courtlistener/mcp/auth.py
@@ -15,12 +15,14 @@ from courtlistener.mcp.settings import (
 logger = logging.getLogger(__name__)
 
 
-async def resolve_user_hash_via_userinfo(token: str) -> str | None:
-    """Return the stable user_hash for *token*, hitting userinfo on cache miss."""
+async def resolve_user_hash_via_userinfo(
+    token: str,
+) -> tuple[str | None, bool]:
+    """Verifies token from cache or via CL's `/o/userinfo/` endpoint."""
     session = get_session()
     cached = await session.get_user_hash(token)
     if cached:
-        return cached
+        return cached, True
 
     try:
         async with httpx.AsyncClient(timeout=USERINFO_TIMEOUT_SECONDS) as http:
@@ -30,45 +32,24 @@ async def resolve_user_hash_via_userinfo(token: str) -> str | None:
             )
     except httpx.HTTPError as exc:
         logger.warning("userinfo call failed: %s", exc)
-        return None
+        return None, False
 
     if resp.status_code != 200:
         # 401 from userinfo == revoked/expired/invalid. Don't cache.
-        return None
+        return None, False
 
     sub = resp.json().get("sub")
     if not sub:
         logger.warning("userinfo response missing `sub` claim")
-        return None
+        return None, False
 
     uh = hmac_hex(str(sub))
     await session.store_user_hash(token, uh)
-    return uh
+    return uh, False
 
 
 class UserInfoTokenVerifier(TokenVerifier):
-    """Verify OAuth tokens by calling CL's OIDC userinfo endpoint.
-
-    Caches token→user_hash mappings in the session store so a burst of
-    tool calls from one session collapses to a single userinfo
-    round-trip. The cached ``user_hash`` is a stable HMAC of the OIDC
-    ``sub`` claim, so session state survives access-token rotation
-    (previously, a refresh silently orphaned the user's namespace).
-
-    Revocation semantics:
-    - A freshly-rejected token surfaces here as a 401 from userinfo →
-      ``verify_token`` returns ``None`` → the auth middleware sends a
-      proper 401 with ``WWW-Authenticate`` so the MCP client re-auths.
-    - A token revoked mid-cache keeps working until the TTL expires or
-      until ``ToolHandlerMiddleware`` sees a 401 from a downstream CL
-      API call, invalidates the cache entry, and forces re-verification
-      on the next request.
-
-    Required scopes (advertised in the protected-resource metadata so
-    MCP clients include them in the authorize request):
-    - ``openid``: needed by DOT's ``/o/userinfo/`` endpoint.
-    - ``api``: CL's custom scope for REST API access.
-    """
+    """Verifies OAuth tokens via CL's `/o/userinfo/` endpoint."""
 
     def __init__(self, *, base_url: str) -> None:
         super().__init__(
@@ -79,17 +60,12 @@ class UserInfoTokenVerifier(TokenVerifier):
     async def verify_token(self, token: str) -> AccessToken | None:
         if not token:
             return None
-        user_hash = await resolve_user_hash_via_userinfo(token)
+        user_hash, from_cache = await resolve_user_hash_via_userinfo(token)
         if user_hash is None:
             return None
-        # Userinfo doesn't return the token's scopes, but a 200 from it
-        # proves the token carries ``openid`` (DOT enforces that). The
-        # ``api`` scope is enforced downstream by CL's REST API itself.
-        # Echoing the required set back here satisfies the middleware's
-        # scope check without a second round-trip to introspection.
         return AccessToken(
             token=token,
             client_id="courtlistener-mcp",
             scopes=list(self.required_scopes),
-            claims={"user_hash": user_hash},
+            claims={"user_hash": user_hash, "cached": from_cache},
         )

--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -35,29 +35,26 @@ class ToolHandlerMiddleware(Middleware):
             result = await mcp_tool(arguments, ctx)
         except CourtListenerAPIError as exc:
             if exc.status_code == 401:
-                # CL rejected a token our verifier previously accepted
-                # (revoked or rotated mid-cache). Drop the cache entry so
-                # the next MCP request re-runs userinfo, fails verification,
-                # and gets a proper HTTP 401 from the auth middleware —
-                # which is what triggers the client's OAuth refresh flow.
-                #
-                # We can't emit the 401 for *this* request from inside the
-                # tool handler (the HTTP response has already committed to
-                # 200 for the JSON-RPC envelope). The tool-level error
-                # below is the best we can do here; the follow-up request
-                # gets the clean signal.
+                # Bust the cache if token rejected by CL
                 try:
                     access_token = get_access_token()
                 except RuntimeError:
                     access_token = None
                 if access_token is not None:
                     await get_session().invalidate_token(access_token.token)
-                raise ToolError(
+                message = (
                     "CourtListener rejected the request as unauthorized. "
                     "Your session may have expired; retry to re-authenticate."
-                ) from exc
+                )
+                if access_token is not None and access_token.claims.get(
+                    "cached"
+                ):
+                    # If it was cached, this is expected. Make exempt.
+                    raise SentryExemptToolError(message) from exc
+                # Otherwise, this is a real disagreement between CL and MCP.
+                raise ToolError(message) from exc
             elif exc.status_code == 429:
-                # Exempt: Routine API rate limit errors.
+                # Routine API rate limit errors are exempt.
                 raise SentryExemptToolError(
                     f"Rate limit exceeded: {exc}. For higher rate limits, "
                     "you can upgrade your membership at https://donate.free.law/forms/membership"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -220,13 +220,31 @@ class TestServerAuthWiring:
         verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
         with patch(
             "courtlistener.mcp.auth.resolve_user_hash_via_userinfo",
-            new=AsyncMock(return_value="fake-user-hash"),
+            new=AsyncMock(return_value=("fake-user-hash", False)),
         ):
             token = asyncio.run(verifier.verify_token("anything-goes"))
         assert token is not None
         assert token.token == "anything-goes"
         assert token.claims.get("user_hash") == "fake-user-hash"
+        assert token.claims.get("cached") is False
         assert set(token.scopes) == {"openid", "api"}
+
+    def test_userinfo_verifier_marks_cache_hits(self):
+        """A cache-served verification is flagged in the claims so the
+        middleware can triage downstream 401s (routine rotation vs.
+        AS/API disagreement)."""
+        import asyncio
+
+        from courtlistener.mcp.auth import UserInfoTokenVerifier
+
+        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
+        with patch(
+            "courtlistener.mcp.auth.resolve_user_hash_via_userinfo",
+            new=AsyncMock(return_value=("fake-user-hash", True)),
+        ):
+            token = asyncio.run(verifier.verify_token("cached-token"))
+        assert token is not None
+        assert token.claims.get("cached") is True
 
     def test_userinfo_verifier_rejects_when_userinfo_fails(self):
         """Userinfo returning ``None`` (401/non-200/network error) →
@@ -241,7 +259,7 @@ class TestServerAuthWiring:
         verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
         with patch(
             "courtlistener.mcp.auth.resolve_user_hash_via_userinfo",
-            new=AsyncMock(return_value=None),
+            new=AsyncMock(return_value=(None, False)),
         ):
             token = asyncio.run(verifier.verify_token("revoked-or-bad"))
         assert token is None

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -1,12 +1,15 @@
 """Sentry exemption for triaged known-noise tool errors.
 
 Routine 429 throttling raises ``SentryExemptToolError``, which the
-``before_send`` hook drops. Everything else — including 401 session
-expiry and upstream 5xx — still reports to Sentry.
+``before_send`` hook drops. 401s are split by how the token passed
+admission: cache-verified tokens that CL rejects are routine
+mid-session rotation (exempt), while freshly-verified tokens that CL
+rejects mean the authorization server and API disagree (reported).
+Upstream 5xx always reports.
 """
 
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -59,8 +62,45 @@ class TestMiddlewareErrorClassification:
         assert "Rate limit exceeded" in str(excinfo.value)
         assert "donate.free.law" in str(excinfo.value)
 
+    def _fake_access_token(self, monkeypatch, cached):
+        token = MagicMock()
+        token.token = "tok"
+        token.claims = {"user_hash": "uh", "cached": cached}
+        monkeypatch.setattr(
+            "courtlistener.mcp.middleware.get_access_token", lambda: token
+        )
+        session = MagicMock()
+        session.invalidate_token = AsyncMock()
+        monkeypatch.setattr(
+            "courtlistener.mcp.middleware.get_session", lambda: session
+        )
+        return session
+
     @pytest.mark.asyncio
-    async def test_401_still_reports(self, monkeypatch):
+    async def test_401_on_cached_token_is_exempt(self, monkeypatch):
+        """Cache-verified token rejected by CL = routine mid-session
+        expiry/rotation: cache busted, error exempt from Sentry."""
+        session = self._fake_access_token(monkeypatch, cached=True)
+        error = _api_error(401, {"detail": "Invalid token."})
+        with pytest.raises(SentryExemptToolError) as excinfo:
+            await _call_tool_raising(monkeypatch, error)
+        assert "retry to re-authenticate" in str(excinfo.value)
+        session.invalidate_token.assert_awaited_once_with("tok")
+
+    @pytest.mark.asyncio
+    async def test_401_on_freshly_verified_token_reports(self, monkeypatch):
+        """Fresh userinfo said valid, CL said invalid: AS/API disagree.
+        This is the outage signature and must keep reporting."""
+        self._fake_access_token(monkeypatch, cached=False)
+        error = _api_error(401, {"detail": "Invalid token."})
+        with pytest.raises(ToolError) as excinfo:
+            await _call_tool_raising(monkeypatch, error)
+        assert not isinstance(excinfo.value, SentryExemptToolError)
+
+    @pytest.mark.asyncio
+    async def test_401_without_token_context_reports(self, monkeypatch):
+        """No access token in context (can't tell cached from fresh):
+        report, conservatively."""
         error = _api_error(401, {"detail": "Invalid token."})
         with pytest.raises(ToolError) as excinfo:
             await _call_tool_raising(monkeypatch, error)


### PR DESCRIPTION
If a user's access_token is cached and expires, the next tool call will get a 401 and bust the cache. This causes the next call to reverify and rotate the token if needed. 

Exempt these 401 errors from sentry, if the token is already cached -- these are routine and happen all the time, expected behavior. If the token wasn't cached however, still propagate these as they represent a real mismatch between CL and the MCP.