### PR TITLE
Split comma separated fields and fingerprint tool arg validation errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ The following changes are not yet released, but are code complete:
 
 Features:
 - Add support for cluster_id in search_document, read_document, and analyze_citations tools.
-- Add support for space or comma-separated values for multiple-choice fields.
+- Add support for space or comma-separated values for multiple-choice fields and `fields` field.
 - Add support for related fields that don't have a schema.
 - Add near-miss suggestions to invalid-choice errors.
 

--- a/courtlistener/mcp/exceptions.py
+++ b/courtlistener/mcp/exceptions.py
@@ -6,6 +6,17 @@ class SentryExemptToolError(ToolError):
     """A `ToolError` triaged as known noise; not reported to Sentry."""
 
 
+class ToolArgumentValidationError(ToolError):
+    """Tool arguments failed input-schema validation."""
+
+    def __init__(
+        self, message: str, tool_name: str, argument_names: list[str]
+    ) -> None:
+        super().__init__(message)
+        self.tool_name = tool_name
+        self.argument_names = argument_names
+
+
 def validation_error_fingerprint(exc: ValidationError) -> list[str]:
     """Fingerprint suffix partitioning ValidationErrors by model + field."""
     fields = sorted(
@@ -21,12 +32,19 @@ def before_send(event, hint):
     """Sentry `before_send` hook.
 
     - Drops exempt-marked tool errors.
+    - Partitions tool-argument schema failures by tool + argument.
     - Partitions ValidationErrors by model + failing field(s).
     """
     exc_info = hint.get("exc_info")
     exc = exc_info[1] if exc_info is not None else None
     if isinstance(exc, SentryExemptToolError):
         return None
-    if isinstance(exc, ValidationError):
+    if isinstance(exc, ToolArgumentValidationError):
+        event["fingerprint"] = [
+            "{{ default }}",
+            exc.tool_name,
+            *sorted(exc.argument_names),
+        ]
+    elif isinstance(exc, ValidationError):
         event["fingerprint"] = validation_error_fingerprint(exc)
     return event

--- a/courtlistener/mcp/tools/get_endpoint_item_tool.py
+++ b/courtlistener/mcp/tools/get_endpoint_item_tool.py
@@ -2,7 +2,10 @@ from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import endpoint_id_property, normalize_fields
+from courtlistener.mcp.tools.utils import (
+    endpoint_id_property,
+    normalize_fields,
+)
 from courtlistener.models import ENDPOINTS
 
 

--- a/courtlistener/mcp/tools/get_endpoint_item_tool.py
+++ b/courtlistener/mcp/tools/get_endpoint_item_tool.py
@@ -2,7 +2,7 @@ from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.mcp.tools.utils import endpoint_id_property
+from courtlistener.mcp.tools.utils import endpoint_id_property, normalize_fields
 from courtlistener.models import ENDPOINTS
 
 
@@ -35,6 +35,7 @@ class GetEndpointItemTool(MCPTool):
                 "fields": {
                     "anyOf": [
                         {"type": "array", "items": {"type": "string"}},
+                        {"type": "string"},
                         {"type": "null"},
                     ],
                     "description": (
@@ -53,7 +54,7 @@ class GetEndpointItemTool(MCPTool):
         """Call the get_endpoint_item tool."""
         endpoint_id = arguments.get("endpoint_id")
         item_id = arguments.get("item_id")
-        fields = arguments.get("fields")
+        fields = normalize_fields(arguments.get("fields"))
 
         if not isinstance(item_id, int | str):
             raise ValueError("Item ID must be a string or integer")

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -13,6 +13,7 @@ from courtlistener.mcp.tools.utils import (
     filter_results_by_fields,
     has_more_results,
     prepare_has_more_str,
+    normalize_fields,
 )
 from courtlistener.resource import ResourceIterator
 
@@ -84,7 +85,9 @@ class GetMoreResultsTool(MCPTool):
                 updated_data["fields"] = fields
             await get_session().store_query(query_id, updated_data, client)
 
-            filtered_results, _ = filter_results_by_fields(results, fields)
+            filtered_results, _ = filter_results_by_fields(
+                results, normalize_fields(fields)
+            )
 
             outputs = {
                 "query_id": query_id,

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -12,8 +12,8 @@ from courtlistener.mcp.tools.utils import (
     collect_results,
     filter_results_by_fields,
     has_more_results,
-    prepare_has_more_str,
     normalize_fields,
+    prepare_has_more_str,
 )
 from courtlistener.resource import ResourceIterator
 

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from functools import cached_property
 from typing import Any
 
-from fastmcp.exceptions import ToolError
 from fastmcp.server.context import Context
 from fastmcp.server.dependencies import get_access_token, get_http_request
 from fastmcp.tools import Tool

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -72,12 +72,19 @@ class MCPTool:
         )
 
     @cached_property
+    def input_schema(self) -> dict:
+        """Cached input schema for the tool."""
+        return self.get_input_schema()
+
+    @cached_property
     def input_validator(self) -> Draft202012Validator:
         """Cached validator for the tool's input schema."""
-        return Draft202012Validator(self.get_input_schema())
+        return Draft202012Validator(self.input_schema)
 
     def validate_arguments(self, arguments: dict) -> None:
         """Check arguments against the tool's input schema."""
+        if self.name is None:
+            raise ValueError("name must be set")
         arguments = {
             key: value for key, value in arguments.items() if value is not None
         }
@@ -101,7 +108,7 @@ class MCPTool:
             elif error.validator == "additionalProperties":
                 # Unexpected keys aren't in error.path; recover them
                 # so Sentry partitions by the unexpected argument.
-                known = self.get_input_schema().get("properties", {})
+                known = self.input_schema.get("properties", {})
                 argument_names.update(
                     key for key in arguments if key not in known
                 )

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -11,6 +11,7 @@ from jsonschema import Draft202012Validator
 from mcp.types import ToolAnnotations
 
 from courtlistener import CourtListener
+from courtlistener.mcp.exceptions import ToolArgumentValidationError
 
 
 class MCPTool:
@@ -89,13 +90,37 @@ class MCPTool:
             return
 
         messages = []
+        argument_names: set[str] = set()
         for error in errors:
             location = ".".join(str(part) for part in error.path)
             prefix = f"{location}: " if location else ""
             messages.append(f"{prefix}{error.message}")
-        raise ToolError(
+            if error.path:
+                # Path points at the failing value; its first segment
+                # is the argument (e.g. a bad `fields` entry).
+                argument_names.add(str(error.path[0]))
+            elif error.validator == "additionalProperties":
+                # Unexpected keys aren't in error.path; recover them
+                # so Sentry partitions by the unexpected argument.
+                known = self.get_input_schema().get("properties", {})
+                argument_names.update(
+                    key for key in arguments if key not in known
+                )
+            elif error.validator == "required":
+                # Missing keys aren't in error.path either; the
+                # schema's required list names them.
+                argument_names.update(
+                    key
+                    for key in error.validator_value
+                    if key not in arguments
+                )
+            else:
+                argument_names.add("__root__")
+        raise ToolArgumentValidationError(
             f"Invalid arguments for tool '{self.name}':\n- "
-            + "\n- ".join(messages)
+            + "\n- ".join(messages),
+            tool_name=self.name,
+            argument_names=sorted(argument_names),
         )
 
     async def __call__(self, arguments: dict, ctx: Context) -> Any:

--- a/courtlistener/mcp/tools/search_tool.py
+++ b/courtlistener/mcp/tools/search_tool.py
@@ -16,6 +16,7 @@ from courtlistener.mcp.tools.utils import (
     prepare_filter,
     prepare_has_more_str,
     prepare_query_id,
+    normalize_fields,
 )
 from courtlistener.models import ENDPOINTS
 
@@ -59,6 +60,7 @@ class SearchTool(MCPTool):
             "fields": {
                 "anyOf": [
                     {"items": {"type": "string"}, "type": "array"},
+                    {"type": "string"},
                     {"type": "null"},
                 ],
                 "description": (
@@ -103,7 +105,7 @@ class SearchTool(MCPTool):
     async def __call__(self, arguments: dict, ctx: Context) -> Any:
         """Call the search tool."""
         with self.get_client() as client:
-            fields = arguments.pop("fields", None)
+            fields = normalize_fields(arguments.pop("fields", None))
             num_results = arguments.pop("num_results", DEFAULT_NUM_RESULTS)
 
             response = client.search.list(**arguments)

--- a/courtlistener/mcp/tools/search_tool.py
+++ b/courtlistener/mcp/tools/search_tool.py
@@ -12,11 +12,11 @@ from courtlistener.mcp.tools.utils import (
     add_opinion_ids,
     collect_results,
     filter_results_by_fields,
+    normalize_fields,
     prepare_count,
     prepare_filter,
     prepare_has_more_str,
     prepare_query_id,
-    normalize_fields,
 )
 from courtlistener.models import ENDPOINTS
 

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import uuid
 from itertools import islice
 
@@ -12,6 +13,13 @@ from courtlistener.models import ENDPOINTS
 from courtlistener.resource import ResourceIterator
 
 logger = logging.getLogger(__name__)
+
+
+def normalize_fields(fields):
+    """Accept comma- or space-separated `fields` strings."""
+    if isinstance(fields, str):
+        return [f for f in re.split(r"[,\s]+", fields.strip(" ,")) if f]
+    return fields
 
 
 def endpoint_id_choices(include_search: bool = False) -> list[str]:

--- a/docs/mcp/tools/get_endpoint_item.inputs.json
+++ b/docs/mcp/tools/get_endpoint_item.inputs.json
@@ -68,6 +68,9 @@
           }
         },
         {
+          "type": "string"
+        },
+        {
           "type": "null"
         }
       ],

--- a/docs/mcp/tools/get_endpoint_item.md
+++ b/docs/mcp/tools/get_endpoint_item.md
@@ -5,7 +5,7 @@
 **Get Item by ID**
 
 - **Source:** `courtlistener/mcp/tools/get_endpoint_item_tool.py`
-- **Estimated definition size:** ~429 tokens (description ~12, input schema ~347; cl100k_base)
+- **Estimated definition size:** ~435 tokens (description ~12, input schema ~353; cl100k_base)
 - **Parameters:** 3 (2 required)
 - **Raw input schema:** [`get_endpoint_item.inputs.json`](./get_endpoint_item.inputs.json)
 
@@ -38,6 +38,6 @@ The ID of the item to get.
 
 ### `fields`
 
-array of string | null · optional
+array of string | string | null · optional
 
 Filter which fields are returned. Use the field names from the endpoint's own schema (see the `get_endpoint_schema` tool), not the field names returned by the `search` tool.

--- a/docs/mcp/tools/search.inputs.json
+++ b/docs/mcp/tools/search.inputs.json
@@ -10,6 +10,9 @@
           "type": "array"
         },
         {
+          "type": "string"
+        },
+        {
           "type": "null"
         }
       ],

--- a/docs/mcp/tools/search.md
+++ b/docs/mcp/tools/search.md
@@ -5,7 +5,7 @@
 **Search**
 
 - **Source:** `courtlistener/mcp/tools/search_tool.py`
-- **Estimated definition size:** ~3269 tokens (description ~78, input schema ~3124; cl100k_base)
+- **Estimated definition size:** ~3275 tokens (description ~78, input schema ~3130; cl100k_base)
 - **Parameters:** 46 (1 required)
 - **Raw input schema:** [`search.inputs.json`](./search.inputs.json)
 
@@ -32,7 +32,7 @@ be useful here.
 
 ### `fields`
 
-array of string | null · optional
+array of string | string | null · optional
 
 Filter which fields are returned. Use the field names as they appear in search results (e.g. `caseName`, `dateFiled`), which differ from the API field names used by `call_endpoint` and `get_endpoint_item`.
 

--- a/tests/test_mcp_argument_validation.py
+++ b/tests/test_mcp_argument_validation.py
@@ -225,3 +225,38 @@ class TestFieldErrors:
         message = str(excinfo.value)
         assert "Did you mean" not in message
         assert "Fields must be one of:" in message
+
+
+class TestFieldsNormalization:
+    """Models pass `fields` as comma/space-separated strings (the
+    CourtListener API's own syntax); tool schemas accept the string
+    form and `normalize_fields` splits it.
+    """
+
+    def test_normalize_comma_separated(self):
+        from courtlistener.mcp.tools.utils import normalize_fields
+
+        assert normalize_fields("id,case_name") == ["id", "case_name"]
+
+    def test_normalize_space_and_mixed(self):
+        from courtlistener.mcp.tools.utils import normalize_fields
+
+        assert normalize_fields("id case_name") == ["id", "case_name"]
+        assert normalize_fields("id, case_name,") == ["id", "case_name"]
+
+    def test_lists_and_none_pass_through(self):
+        from courtlistener.mcp.tools.utils import normalize_fields
+
+        assert normalize_fields(["id"]) == ["id"]
+        assert normalize_fields(None) is None
+
+    @pytest.mark.parametrize("tool", ["search", "get_endpoint_item"])
+    def test_schema_accepts_string_fields(self, tool):
+        schema = MCP_TOOLS[tool].get_input_schema()
+        anyof = schema["properties"]["fields"]["anyOf"]
+        assert {"type": "string"} in anyof
+
+    def test_search_validate_arguments_accepts_comma_string(self):
+        MCP_TOOLS["search"].validate_arguments(
+            {"type": "o", "q": "test", "fields": "caseName,dateFiled"}
+        )

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -156,3 +156,60 @@ class TestValidationErrorFingerprint:
         result = before_send(event, {"exc_info": (RuntimeError, err, None)})
         assert result is event
         assert "fingerprint" not in result
+
+
+class TestToolArgumentFingerprint:
+    """Argument-schema failures get partitioned by tool + argument so
+    the monolithic bucket (Sentry MCP-2H) splits into per-cause issues.
+    The error stays a ToolError subclass, so the model-facing message
+    is unchanged.
+    """
+
+    def _error_for(self, tool, arguments):
+        from courtlistener.mcp.exceptions import ToolArgumentValidationError
+        from courtlistener.mcp.tools import MCP_TOOLS
+
+        with pytest.raises(ToolArgumentValidationError) as exc_info:
+            MCP_TOOLS[tool].validate_arguments(arguments)
+        return exc_info.value
+
+    def test_unexpected_property_names_the_argument(self):
+        # The MCP-2H sample: models passing call_endpoint's `query`
+        # shape to search. error.path is empty for
+        # additionalProperties, so names are recovered from arguments.
+        exc = self._error_for("search", {"type": "o", "query": {"q": "x"}})
+        assert exc.tool_name == "search"
+        assert exc.argument_names == ["query"]
+        assert isinstance(exc, ToolError)
+
+    def test_missing_required_names_the_argument(self):
+        # `required` violations also have an empty error.path; the
+        # missing names come from the schema's required list.
+        exc = self._error_for("search", {"q": "test"})
+        assert exc.argument_names == ["type"]
+
+    def test_bad_value_names_the_argument(self):
+        exc = self._error_for("search", {"type": "o", "fields": 123})
+        assert exc.argument_names == ["fields"]
+
+    def test_before_send_partitions_by_tool_and_argument(self):
+        from courtlistener.mcp.exceptions import before_send
+
+        exc = self._error_for("search", {"type": "o", "query": {}})
+        event = {}
+        result = before_send(event, {"exc_info": (type(exc), exc, None)})
+        assert result is event
+        assert result["fingerprint"] == ["{{ default }}", "search", "query"]
+
+    def test_different_causes_get_different_fingerprints(self):
+        from courtlistener.mcp.exceptions import before_send
+
+        def fingerprint(tool, arguments):
+            exc = self._error_for(tool, arguments)
+            event = {}
+            before_send(event, {"exc_info": (type(exc), exc, None)})
+            return event["fingerprint"]
+
+        assert fingerprint(
+            "search", {"type": "o", "query": {}}
+        ) != fingerprint("search", {"type": "o", "fields": 123})


### PR DESCRIPTION
This PR does two things:

1. Adds support for comma separated strings for `fields` fields in mcp tools. Similar to the earlier PR related to courts, models just aren't respecting our tool input schemas and prefer to write inputs as they would if creating url params for the CL API directly.

2. Also adds a `ToolCallValidationError` that keys errors on (tool, arguments) for more granular sentry visibility.