### PR TITLE
feat(sentry): key sentry validation errors by model and tool only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Features:
 Changes:
 - Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.
 - Add terms and privacy policy to index.html.
-- Fingerprint validation errors by model and field for Sentry.
+- Fingerprint validation errors by model or tool for Sentry.
 - Exempt routine token rotation errors from Sentry.
 
 Fixes:

--- a/courtlistener/mcp/exceptions.py
+++ b/courtlistener/mcp/exceptions.py
@@ -9,42 +9,24 @@ class SentryExemptToolError(ToolError):
 class ToolArgumentValidationError(ToolError):
     """Tool arguments failed input-schema validation."""
 
-    def __init__(
-        self, message: str, tool_name: str, argument_names: list[str]
-    ) -> None:
+    def __init__(self, message: str, tool_name: str) -> None:
         super().__init__(message)
         self.tool_name = tool_name
-        self.argument_names = argument_names
-
-
-def validation_error_fingerprint(exc: ValidationError) -> list[str]:
-    """Fingerprint suffix partitioning ValidationErrors by model + field."""
-    fields = sorted(
-        {
-            str(err["loc"][0]) if err["loc"] else "__root__"
-            for err in exc.errors()
-        }
-    )
-    return ["{{ default }}", exc.title, *fields]
 
 
 def before_send(event, hint):
     """Sentry `before_send` hook.
 
     - Drops exempt-marked tool errors.
-    - Partitions tool-argument schema failures by tool + argument.
-    - Partitions ValidationErrors by model + failing field(s).
+    - Partitions tool-argument schema failures by tool.
+    - Partitions ValidationErrors by model.
     """
     exc_info = hint.get("exc_info")
     exc = exc_info[1] if exc_info is not None else None
     if isinstance(exc, SentryExemptToolError):
         return None
     if isinstance(exc, ToolArgumentValidationError):
-        event["fingerprint"] = [
-            "{{ default }}",
-            exc.tool_name,
-            *sorted(exc.argument_names),
-        ]
+        event["fingerprint"] = ["{{ default }}", exc.tool_name]
     elif isinstance(exc, ValidationError):
-        event["fingerprint"] = validation_error_fingerprint(exc)
+        event["fingerprint"] = ["{{ default }}", exc.title]
     return event

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -96,37 +96,14 @@ class MCPTool:
             return
 
         messages = []
-        argument_names: set[str] = set()
         for error in errors:
             location = ".".join(str(part) for part in error.path)
             prefix = f"{location}: " if location else ""
             messages.append(f"{prefix}{error.message}")
-            if error.path:
-                # Path points at the failing value; its first segment
-                # is the argument (e.g. a bad `fields` entry).
-                argument_names.add(str(error.path[0]))
-            elif error.validator == "additionalProperties":
-                # Unexpected keys aren't in error.path; recover them
-                # so Sentry partitions by the unexpected argument.
-                known = self.input_schema.get("properties", {})
-                argument_names.update(
-                    key for key in arguments if key not in known
-                )
-            elif error.validator == "required":
-                # Missing keys aren't in error.path either; the
-                # schema's required list names them.
-                argument_names.update(
-                    key
-                    for key in error.validator_value
-                    if key not in arguments
-                )
-            else:
-                argument_names.add("__root__")
         raise ToolArgumentValidationError(
             f"Invalid arguments for tool '{self.name}':\n- "
             + "\n- ".join(messages),
             tool_name=self.name,
-            argument_names=sorted(argument_names),
         )
 
     async def __call__(self, arguments: dict, ctx: Context) -> Any:

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -137,9 +137,7 @@ class TestBeforeSend:
 
 
 class TestValidationErrorFingerprint:
-    """ValidationErrors get partitioned by model + failing field so the
-    old monolithic bucket (Sentry MCP-G) splits into per-field issues.
-    """
+    """ValidationErrors get partitioned by model."""
 
     def _validation_error(self, **kwargs):
         from pydantic import ValidationError
@@ -154,27 +152,6 @@ class TestValidationErrorFingerprint:
             return exc
         raise AssertionError("expected ValidationError")
 
-    def test_fingerprint_includes_model_and_field(self):
-        from courtlistener.mcp.exceptions import validation_error_fingerprint
-
-        exc = self._validation_error(court="njsupct")
-        assert validation_error_fingerprint(exc) == [
-            "{{ default }}",
-            "OpinionSearchEndpoint",
-            "court",
-        ]
-
-    def test_different_fields_get_different_fingerprints(self):
-        from courtlistener.mcp.exceptions import validation_error_fingerprint
-
-        court = validation_error_fingerprint(
-            self._validation_error(court="njsupct")
-        )
-        order_by = validation_error_fingerprint(
-            self._validation_error(order_by="relevance desc")
-        )
-        assert court != order_by
-
     def test_before_send_sets_fingerprint(self):
         from courtlistener.mcp.exceptions import before_send
 
@@ -185,8 +162,19 @@ class TestValidationErrorFingerprint:
         assert result["fingerprint"] == [
             "{{ default }}",
             "OpinionSearchEndpoint",
-            "court",
         ]
+
+    def test_different_fields_share_a_fingerprint(self):
+        from courtlistener.mcp.exceptions import before_send
+
+        def fingerprint(exc):
+            event = {}
+            before_send(event, {"exc_info": (type(exc), exc, None)})
+            return event["fingerprint"]
+
+        assert fingerprint(
+            self._validation_error(court="njsupct")
+        ) == fingerprint(self._validation_error(order_by="relevance desc"))
 
     def test_before_send_leaves_other_errors_alone(self):
         from courtlistener.mcp.exceptions import before_send
@@ -199,11 +187,7 @@ class TestValidationErrorFingerprint:
 
 
 class TestToolArgumentFingerprint:
-    """Argument-schema failures get partitioned by tool + argument so
-    the monolithic bucket (Sentry MCP-2H) splits into per-cause issues.
-    The error stays a ToolError subclass, so the model-facing message
-    is unchanged.
-    """
+    """Argument-schema failures get partitioned by tool."""
 
     def _error_for(self, tool, arguments):
         from courtlistener.mcp.exceptions import ToolArgumentValidationError
@@ -213,35 +197,21 @@ class TestToolArgumentFingerprint:
             MCP_TOOLS[tool].validate_arguments(arguments)
         return exc_info.value
 
-    def test_unexpected_property_names_the_argument(self):
-        # The MCP-2H sample: models passing call_endpoint's `query`
-        # shape to search. error.path is empty for
-        # additionalProperties, so names are recovered from arguments.
+    def test_error_carries_tool_name(self):
         exc = self._error_for("search", {"type": "o", "query": {"q": "x"}})
         assert exc.tool_name == "search"
-        assert exc.argument_names == ["query"]
         assert isinstance(exc, ToolError)
 
-    def test_missing_required_names_the_argument(self):
-        # `required` violations also have an empty error.path; the
-        # missing names come from the schema's required list.
-        exc = self._error_for("search", {"q": "test"})
-        assert exc.argument_names == ["type"]
-
-    def test_bad_value_names_the_argument(self):
-        exc = self._error_for("search", {"type": "o", "fields": 123})
-        assert exc.argument_names == ["fields"]
-
-    def test_before_send_partitions_by_tool_and_argument(self):
+    def test_before_send_partitions_by_tool(self):
         from courtlistener.mcp.exceptions import before_send
 
         exc = self._error_for("search", {"type": "o", "query": {}})
         event = {}
         result = before_send(event, {"exc_info": (type(exc), exc, None)})
         assert result is event
-        assert result["fingerprint"] == ["{{ default }}", "search", "query"]
+        assert result["fingerprint"] == ["{{ default }}", "search"]
 
-    def test_different_causes_get_different_fingerprints(self):
+    def test_different_arguments_share_a_fingerprint(self):
         from courtlistener.mcp.exceptions import before_send
 
         def fingerprint(tool, arguments):
@@ -252,4 +222,4 @@ class TestToolArgumentFingerprint:
 
         assert fingerprint(
             "search", {"type": "o", "query": {}}
-        ) != fingerprint("search", {"type": "o", "fields": 123})
+        ) == fingerprint("search", {"type": "o", "fields": 123})


### PR DESCRIPTION
The current way we're handling validation errors is generating too much noise on sentry. There are thousands of possible model x field and tool x argument combinations. This PR reduces the granularity of sentry fingerprints for `ValidationError` and `ToolCallValidationError` by dropping fields/argument from the fingerprint. Moving forward there will be 48 endpoint + 16 tool call buckets max that these errors can fall into.