### PR TITLE
feat(sentry): consolidate validation errors and add tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Features:
 Changes:
 - Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.
 - Add terms and privacy policy to index.html.
-- Fingerprint validation errors by model or tool for Sentry.
+- Tag `ValidationError` and `ToolArgumentValidationError` errors by model or tool for Sentry.
 - Exempt routine token rotation errors from Sentry.
 
 Fixes:

--- a/courtlistener/mcp/exceptions.py
+++ b/courtlistener/mcp/exceptions.py
@@ -9,24 +9,49 @@ class SentryExemptToolError(ToolError):
 class ToolArgumentValidationError(ToolError):
     """Tool arguments failed input-schema validation."""
 
-    def __init__(self, message: str, tool_name: str) -> None:
+    def __init__(
+        self, message: str, tool_name: str, argument_names: list[str]
+    ) -> None:
         super().__init__(message)
         self.tool_name = tool_name
+        self.argument_names = argument_names
+
+
+def validation_error_fields(exc: ValidationError) -> list[str]:
+    """Top-level field names that failed validation."""
+    return sorted(
+        {
+            str(err["loc"][0]) if err["loc"] else "__root__"
+            for err in exc.errors()
+        }
+    )
 
 
 def before_send(event, hint):
     """Sentry `before_send` hook.
 
     - Drops exempt-marked tool errors.
-    - Partitions tool-argument schema failures by tool.
-    - Partitions ValidationErrors by model.
+    - ToolArgumentValidationErrors tagged by tool and arguments.
+    - ValidationErrors tagged by model and fields.
     """
     exc_info = hint.get("exc_info")
     exc = exc_info[1] if exc_info is not None else None
     if isinstance(exc, SentryExemptToolError):
         return None
     if isinstance(exc, ToolArgumentValidationError):
-        event["fingerprint"] = ["{{ default }}", exc.tool_name]
+        event["fingerprint"] = ["tool-argument-validation"]
+        event.setdefault("tags", {}).update(
+            {
+                "tool": exc.tool_name,
+                "field": ",".join(exc.argument_names),
+            }
+        )
     elif isinstance(exc, ValidationError):
-        event["fingerprint"] = ["{{ default }}", exc.title]
+        event["fingerprint"] = ["endpoint-model-validation"]
+        event.setdefault("tags", {}).update(
+            {
+                "model": exc.title,
+                "field": ",".join(validation_error_fields(exc)),
+            }
+        )
     return event

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -96,14 +96,31 @@ class MCPTool:
             return
 
         messages = []
+        argument_names: set[str] = set()
         for error in errors:
             location = ".".join(str(part) for part in error.path)
             prefix = f"{location}: " if location else ""
             messages.append(f"{prefix}{error.message}")
+            if error.path:
+                argument_names.add(str(error.path[0]))
+            elif error.validator == "additionalProperties":
+                known = self.input_schema.get("properties", {})
+                argument_names.update(
+                    key for key in arguments if key not in known
+                )
+            elif error.validator == "required":
+                argument_names.update(
+                    key
+                    for key in error.validator_value
+                    if key not in arguments
+                )
+            else:
+                argument_names.add("__root__")
         raise ToolArgumentValidationError(
             f"Invalid arguments for tool '{self.name}':\n- "
             + "\n- ".join(messages),
             tool_name=self.name,
+            argument_names=sorted(argument_names),
         )
 
     async def __call__(self, arguments: dict, ctx: Context) -> Any:

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -137,7 +137,9 @@ class TestBeforeSend:
 
 
 class TestValidationErrorFingerprint:
-    """ValidationErrors get partitioned by model."""
+    """All ValidationErrors share one issue; `model` and `field` tags
+    carry the breakdown for the issue-page tag view and dashboards.
+    """
 
     def _validation_error(self, **kwargs):
         from pydantic import ValidationError
@@ -152,29 +154,37 @@ class TestValidationErrorFingerprint:
             return exc
         raise AssertionError("expected ValidationError")
 
-    def test_before_send_sets_fingerprint(self):
+    def test_before_send_sets_fingerprint_and_tags(self):
         from courtlistener.mcp.exceptions import before_send
 
         exc = self._validation_error(court="njsupct")
         event = {}
         result = before_send(event, {"exc_info": (type(exc), exc, None)})
         assert result is event
-        assert result["fingerprint"] == [
-            "{{ default }}",
-            "OpinionSearchEndpoint",
-        ]
+        assert result["fingerprint"] == ["endpoint-model-validation"]
+        assert result["tags"] == {
+            "model": "OpinionSearchEndpoint",
+            "field": "court",
+        }
 
-    def test_different_fields_share_a_fingerprint(self):
+    def test_multiple_fields_join_in_field_tag(self):
         from courtlistener.mcp.exceptions import before_send
 
-        def fingerprint(exc):
-            event = {}
-            before_send(event, {"exc_info": (type(exc), exc, None)})
-            return event["fingerprint"]
+        exc = self._validation_error(
+            court="njsupct", order_by="relevance desc"
+        )
+        event = {}
+        before_send(event, {"exc_info": (type(exc), exc, None)})
+        assert event["tags"]["field"] == "court,order_by"
 
-        assert fingerprint(
-            self._validation_error(court="njsupct")
-        ) == fingerprint(self._validation_error(order_by="relevance desc"))
+    def test_existing_tags_are_preserved(self):
+        from courtlistener.mcp.exceptions import before_send
+
+        exc = self._validation_error(court="njsupct")
+        event = {"tags": {"release": "1.0"}}
+        before_send(event, {"exc_info": (type(exc), exc, None)})
+        assert event["tags"]["release"] == "1.0"
+        assert event["tags"]["model"] == "OpinionSearchEndpoint"
 
     def test_before_send_leaves_other_errors_alone(self):
         from courtlistener.mcp.exceptions import before_send
@@ -187,7 +197,10 @@ class TestValidationErrorFingerprint:
 
 
 class TestToolArgumentFingerprint:
-    """Argument-schema failures get partitioned by tool."""
+    """All argument-schema failures share one issue; `tool` and `field`
+    tags carry the breakdown. The error stays a ToolError subclass, so
+    the model-facing message is unchanged.
+    """
 
     def _error_for(self, tool, arguments):
         from courtlistener.mcp.exceptions import ToolArgumentValidationError
@@ -197,29 +210,40 @@ class TestToolArgumentFingerprint:
             MCP_TOOLS[tool].validate_arguments(arguments)
         return exc_info.value
 
-    def test_error_carries_tool_name(self):
+    def test_unexpected_property_names_the_argument(self):
+        # The historical MCP-2H sample: models passing call_endpoint's
+        # `query` shape to search. error.path is empty for
+        # additionalProperties, so names are recovered from arguments.
         exc = self._error_for("search", {"type": "o", "query": {"q": "x"}})
         assert exc.tool_name == "search"
+        assert exc.argument_names == ["query"]
         assert isinstance(exc, ToolError)
 
-    def test_before_send_partitions_by_tool(self):
+    def test_missing_required_names_the_argument(self):
+        # `required` violations also have an empty error.path; the
+        # missing names come from the schema's required list.
+        exc = self._error_for("search", {"q": "test"})
+        assert exc.argument_names == ["type"]
+
+    def test_bad_value_names_the_argument(self):
+        exc = self._error_for("search", {"type": "o", "fields": 123})
+        assert exc.argument_names == ["fields"]
+
+    def test_before_send_sets_fingerprint_and_tags(self):
         from courtlistener.mcp.exceptions import before_send
 
         exc = self._error_for("search", {"type": "o", "query": {}})
         event = {}
         result = before_send(event, {"exc_info": (type(exc), exc, None)})
         assert result is event
-        assert result["fingerprint"] == ["{{ default }}", "search"]
+        assert result["fingerprint"] == ["tool-argument-validation"]
+        assert result["tags"] == {"tool": "search", "field": "query"}
 
-    def test_different_arguments_share_a_fingerprint(self):
+    def test_multiple_arguments_join_in_field_tag(self):
         from courtlistener.mcp.exceptions import before_send
 
-        def fingerprint(tool, arguments):
-            exc = self._error_for(tool, arguments)
-            event = {}
-            before_send(event, {"exc_info": (type(exc), exc, None)})
-            return event["fingerprint"]
-
-        assert fingerprint(
-            "search", {"type": "o", "query": {}}
-        ) == fingerprint("search", {"type": "o", "fields": 123})
+        exc = self._error_for("search", {"query": {}, "fields": 123})
+        event = {}
+        before_send(event, {"exc_info": (type(exc), exc, None)})
+        assert event["tags"]["tool"] == "search"
+        assert event["tags"]["field"] == "fields,query,type"


### PR DESCRIPTION
Flip-flopping on how to handle validation errors. Instead we'll use sentry tags for distinguishing errors related to different endpoints/fields and tools/arguments. Less alert noise, still the ability to break down errors by tag. Multi-field errors tagged as comma separated.