### PR TITLE
feat(sentry): bundle unauthorized tool errors to a single sentry issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Changes:
 - Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.
 - Add terms and privacy policy to index.html.
 - Tag `ValidationError` and `ToolArgumentValidationError` errors by model or tool for Sentry.
+- Tag `UnauthorizedToolError` errors by tool for Sentry.
 - Exempt routine token rotation errors from Sentry.
 
 Fixes:

--- a/courtlistener/mcp/exceptions.py
+++ b/courtlistener/mcp/exceptions.py
@@ -17,6 +17,14 @@ class ToolArgumentValidationError(ToolError):
         self.argument_names = argument_names
 
 
+class UnauthorizedToolError(ToolError):
+    """CL rejected a freshly-verified token as unauthorized."""
+
+    def __init__(self, message: str, tool_name: str) -> None:
+        super().__init__(message)
+        self.tool_name = tool_name
+
+
 def validation_error_fields(exc: ValidationError) -> list[str]:
     """Top-level field names that failed validation."""
     return sorted(
@@ -33,12 +41,16 @@ def before_send(event, hint):
     - Drops exempt-marked tool errors.
     - ToolArgumentValidationErrors tagged by tool and arguments.
     - ValidationErrors tagged by model and fields.
+    - UnauthorizedToolErrors tagged by tool.
     """
     exc_info = hint.get("exc_info")
     exc = exc_info[1] if exc_info is not None else None
     if isinstance(exc, SentryExemptToolError):
         return None
-    if isinstance(exc, ToolArgumentValidationError):
+    if isinstance(exc, UnauthorizedToolError):
+        event["fingerprint"] = ["unauthorized-tool-call"]
+        event.setdefault("tags", {}).update({"tool": exc.tool_name})
+    elif isinstance(exc, ToolArgumentValidationError):
         event["fingerprint"] = ["tool-argument-validation"]
         event.setdefault("tags", {}).update(
             {

--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -8,7 +8,10 @@ from fastmcp.tools import ToolResult
 from mcp.types import TextContent
 
 from courtlistener.exceptions import CourtListenerAPIError
-from courtlistener.mcp.exceptions import SentryExemptToolError
+from courtlistener.mcp.exceptions import (
+    SentryExemptToolError,
+    UnauthorizedToolError,
+)
 from courtlistener.mcp.session import get_session, json_default
 from courtlistener.mcp.tools import MCP_TOOLS
 
@@ -52,7 +55,7 @@ class ToolHandlerMiddleware(Middleware):
                     # If it was cached, this is expected. Make exempt.
                     raise SentryExemptToolError(message) from exc
                 # Otherwise, this is a real disagreement between CL and MCP.
-                raise ToolError(message) from exc
+                raise UnauthorizedToolError(message, tool_name=name) from exc
             elif exc.status_code == 429:
                 # Routine API rate limit errors are exempt.
                 raise SentryExemptToolError(

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -18,6 +18,7 @@ from fastmcp.exceptions import ToolError
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.mcp.exceptions import (
     SentryExemptToolError,
+    UnauthorizedToolError,
     before_send,
 )
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
@@ -93,18 +94,17 @@ class TestMiddlewareErrorClassification:
         This is the outage signature and must keep reporting."""
         self._fake_access_token(monkeypatch, cached=False)
         error = _api_error(401, {"detail": "Invalid token."})
-        with pytest.raises(ToolError) as excinfo:
+        with pytest.raises(UnauthorizedToolError) as excinfo:
             await _call_tool_raising(monkeypatch, error)
-        assert not isinstance(excinfo.value, SentryExemptToolError)
+        assert excinfo.value.tool_name == "fake_tool"
 
     @pytest.mark.asyncio
     async def test_401_without_token_context_reports(self, monkeypatch):
         """No access token in context (can't tell cached from fresh):
         report, conservatively."""
         error = _api_error(401, {"detail": "Invalid token."})
-        with pytest.raises(ToolError) as excinfo:
+        with pytest.raises(UnauthorizedToolError):
             await _call_tool_raising(monkeypatch, error)
-        assert not isinstance(excinfo.value, SentryExemptToolError)
 
     @pytest.mark.asyncio
     async def test_upstream_500_still_reports(self, monkeypatch):
@@ -247,3 +247,28 @@ class TestToolArgumentFingerprint:
         before_send(event, {"exc_info": (type(exc), exc, None)})
         assert event["tags"]["tool"] == "search"
         assert event["tags"]["field"] == "fields,query,type"
+
+
+class TestUnauthorizedFingerprint:
+    """All fresh-token 401 rejections share one issue; the chained
+    CourtListenerAPIError's stack trace differs per tool and client
+    code path, which would otherwise split default grouping into a
+    bucket per call path. A `tool` tag carries the breakdown.
+    """
+
+    def test_before_send_sets_fingerprint_and_tags(self):
+        exc = UnauthorizedToolError("unauthorized", tool_name="search")
+        event = {}
+        result = before_send(event, {"exc_info": (type(exc), exc, None)})
+        assert result is event
+        assert result["fingerprint"] == ["unauthorized-tool-call"]
+        assert result["tags"] == {"tool": "search"}
+
+    def test_different_tools_share_a_fingerprint(self):
+        def fingerprint(tool):
+            exc = UnauthorizedToolError("unauthorized", tool_name=tool)
+            event = {}
+            before_send(event, {"exc_info": (type(exc), exc, None)})
+            return event["fingerprint"]
+
+        assert fingerprint("search") == fingerprint("analyze_citations")


### PR DESCRIPTION
Add's `UnauthorizedToolError` and bundles these into a single sentry issue tagged by tool.