### PR TITLE
Inline validation errors, invalid field errors, and missing session data errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ Changes:
 - Tag `ValidationError` and `ToolArgumentValidationError` errors by model or tool for Sentry.
 - Tag `UnauthorizedToolError` errors by tool for Sentry.
 - Key upstream CourtListener failures (5xx and transport errors) by status for Sentry, tagged by tool and status.
+- Raise `ToolArgumentValidationError` for in-tool argument guards so they share the tool-argument Sentry issue.
+- Add `InvalidFieldsError` for invalid `fields` requests, mapped to `ToolArgumentValidationError` in the MCP middleware.
+- Add `SessionDataNotFoundError` for stale query/job ids, keyed as its own Sentry issue so spikes surface session-store problems.
 - Exempt routine token rotation errors from Sentry.
 
 Fixes:

--- a/courtlistener/exceptions.py
+++ b/courtlistener/exceptions.py
@@ -5,6 +5,10 @@ from typing import Any
 import httpx
 
 
+class InvalidFieldsError(ValueError):
+    """Requested `fields` include names the endpoint doesn't offer."""
+
+
 class CourtListenerAPIError(Exception):
     """Raised when the CourtListener API returns an error response.
 

--- a/courtlistener/mcp/exceptions.py
+++ b/courtlistener/mcp/exceptions.py
@@ -25,6 +25,17 @@ class UnauthorizedToolError(ToolError):
         self.tool_name = tool_name
 
 
+class SessionDataNotFoundError(ToolError):
+    """A session-scoped ID (query, job) has no stored data."""
+
+    def __init__(
+        self, message: str, tool_name: str, argument_name: str
+    ) -> None:
+        super().__init__(message)
+        self.tool_name = tool_name
+        self.argument_name = argument_name
+
+
 class UpstreamCourtListenerError(ToolError):
     """The upstream CL request failed: 5xx or transport error."""
 
@@ -52,12 +63,21 @@ def before_send(event, hint):
     - ValidationErrors tagged by model and fields.
     - UnauthorizedToolErrors tagged by tool.
     - UpstreamCourtListenerErrors keyed by status, tagged by tool and status.
+    - SessionDataNotFoundErrors tagged by tool and field.
     """
     exc_info = hint.get("exc_info")
     exc = exc_info[1] if exc_info is not None else None
     if isinstance(exc, SentryExemptToolError):
         return None
-    if isinstance(exc, UnauthorizedToolError):
+    if isinstance(exc, SessionDataNotFoundError):
+        event["fingerprint"] = ["session-data-not-found"]
+        event.setdefault("tags", {}).update(
+            {
+                "tool": exc.tool_name,
+                "field": exc.argument_name,
+            }
+        )
+    elif isinstance(exc, UnauthorizedToolError):
         event["fingerprint"] = ["unauthorized-tool-call"]
         event.setdefault("tags", {}).update({"tool": exc.tool_name})
     elif isinstance(exc, UpstreamCourtListenerError):

--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -7,9 +7,13 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 from mcp.types import TextContent
 
-from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.exceptions import (
+    CourtListenerAPIError,
+    InvalidFieldsError,
+)
 from courtlistener.mcp.exceptions import (
     SentryExemptToolError,
+    ToolArgumentValidationError,
     UnauthorizedToolError,
     UpstreamCourtListenerError,
 )
@@ -37,6 +41,10 @@ class ToolHandlerMiddleware(Middleware):
 
         try:
             result = await mcp_tool(arguments, ctx)
+        except InvalidFieldsError as exc:
+            raise ToolArgumentValidationError(
+                str(exc), tool_name=name, argument_names=["fields"]
+            ) from exc
         except CourtListenerAPIError as exc:
             if exc.status_code == 401:
                 # Bust the cache if token rejected by CL

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -52,7 +52,7 @@ class AnalyzeCitationsTool(MCPTool):
     canonical name, a WARNING is emitted flagging a possible
     hallucinated citation.
 
-    Input should include exactly one of opinion_id, recap_document_id, or cluster_id.
+    Input should include exactly one of opinion_id or cluster_id.
     """
 
     name: str = "analyze_citations"

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -8,6 +8,7 @@ from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.mcp.exceptions import ToolArgumentValidationError
 from courtlistener.mcp.session import get_session
 from courtlistener.mcp.tools.citation_utils import (
     MAX_CITATIONS_PER_REQUEST,
@@ -50,6 +51,8 @@ class AnalyzeCitationsTool(MCPTool):
     its input case name differs significantly from the cluster's
     canonical name, a WARNING is emitted flagging a possible
     hallucinated citation.
+
+    Input should include exactly one of opinion_id, recap_document_id, or cluster_id.
     """
 
     name: str = "analyze_citations"
@@ -105,8 +108,10 @@ class AnalyzeCitationsTool(MCPTool):
             if value is not None
         ]
         if len(provided) != 1:
-            raise ValueError(
-                "Provide exactly one of text, opinion_id, or cluster_id."
+            raise ToolArgumentValidationError(
+                "Provide exactly one of text, opinion_id, or cluster_id.",
+                tool_name=self.name,
+                argument_names=["cluster_id", "opinion_id", "text"],
             )
 
         note = ""

--- a/courtlistener/mcp/tools/get_choices_tool.py
+++ b/courtlistener/mcp/tools/get_choices_tool.py
@@ -3,6 +3,7 @@ from typing import Literal, get_args, get_origin
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.mcp.exceptions import ToolArgumentValidationError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import endpoint_id_property
 from courtlistener.models import ENDPOINTS
@@ -72,10 +73,12 @@ class GetChoicesTool(MCPTool):
 
             field_info = endpoint.model_fields.get(field_name)
             if field_info is None:
-                raise ValueError(
+                raise ToolArgumentValidationError(
                     f"Field '{field_name}' not found on endpoint "
                     f"'{endpoint_id}'."
-                    f"{did_you_mean(field_name, list(endpoint.model_fields))}"
+                    f"{did_you_mean(field_name, list(endpoint.model_fields))}",
+                    tool_name=self.name,
+                    argument_names=["field_name"],
                 )
 
             extra = getattr(field_info, "json_schema_extra", {}) or {}

--- a/courtlistener/mcp/tools/get_counts_tool.py
+++ b/courtlistener/mcp/tools/get_counts_tool.py
@@ -1,6 +1,7 @@
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.mcp.exceptions import SessionDataNotFoundError
 from courtlistener.mcp.session import get_session
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.resource import ResourceIterator
@@ -41,9 +42,11 @@ class GetCountsTool(MCPTool):
         with self.get_client() as client:
             data = await get_session().get_query(query_id, client)
             if data is None:
-                raise ValueError(
+                raise SessionDataNotFoundError(
                     f"Query ID {query_id!r} not found. The session may have "
-                    "expired, please redo the query first."
+                    "expired, please redo the query first.",
+                    tool_name=self.name,
+                    argument_name="query_id",
                 )
             response = ResourceIterator.load(client, data["response"])
             count = response.count

--- a/courtlistener/mcp/tools/get_endpoint_item_tool.py
+++ b/courtlistener/mcp/tools/get_endpoint_item_tool.py
@@ -59,9 +59,6 @@ class GetEndpointItemTool(MCPTool):
         item_id = arguments.get("item_id")
         fields = normalize_fields(arguments.get("fields"))
 
-        if not isinstance(item_id, int | str):
-            raise ValueError("Item ID must be a string or integer")
-
         for endpoint_name, endpoint in ENDPOINTS.items():
             if endpoint.endpoint_id == endpoint_id:
                 with self.get_client() as client:

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -1,6 +1,7 @@
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.mcp.exceptions import SessionDataNotFoundError
 from courtlistener.mcp.session import get_session
 from courtlistener.mcp.settings import (
     DEFAULT_NUM_RESULTS,
@@ -66,9 +67,11 @@ class GetMoreResultsTool(MCPTool):
         with self.get_client() as client:
             query = await get_session().get_query(query_id, client)
             if query is None:
-                raise ValueError(
+                raise SessionDataNotFoundError(
                     f"Query ID {query_id!r} not found. The session may have "
-                    "expired, please redo the query first."
+                    "expired, please redo the query first.",
+                    tool_name=self.name,
+                    argument_name="query_id",
                 )
 
             response = ResourceIterator.load(client, query["response"])

--- a/courtlistener/mcp/tools/read_document_tool.py
+++ b/courtlistener/mcp/tools/read_document_tool.py
@@ -3,6 +3,7 @@ import math
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.mcp.exceptions import ToolArgumentValidationError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import (
     fetch_document_text,
@@ -34,6 +35,8 @@ class ReadDocumentTool(MCPTool):
       non-contiguous windows in a single call (up to
       10).  Useful when you already know the chunk
       size from a previous call and want the next N pages at once.
+
+    Input should include exactly one of opinion_id, recap_document_id, or cluster_id.
     """
 
     name: str = "read_document"
@@ -104,9 +107,15 @@ class ReadDocumentTool(MCPTool):
             if value is not None
         ]
         if len(provided) != 1:
-            raise ValueError(
+            raise ToolArgumentValidationError(
                 "Provide exactly one of opinion_id, recap_document_id, "
-                "or cluster_id."
+                "or cluster_id.",
+                tool_name=self.name,
+                argument_names=[
+                    "cluster_id",
+                    "opinion_id",
+                    "recap_document_id",
+                ],
             )
 
         chunk_index = arguments.get("chunk_index")
@@ -159,10 +168,12 @@ class ReadDocumentTool(MCPTool):
         elif isinstance(chunk_index, list):
             out_of_range = [i for i in chunk_index if i >= total_chunks]
             if out_of_range:
-                raise ValueError(
+                raise ToolArgumentValidationError(
                     f"chunk_index value(s) {out_of_range} are out of range; "
                     f"document has {total_chunks} chunk(s) of "
-                    f"{chunk_size} characters each."
+                    f"{chunk_size} characters each.",
+                    tool_name=self.name,
+                    argument_names=["chunk_index"],
                 )
             result["chunk_size"] = chunk_size
             result["total_chunks"] = total_chunks
@@ -175,10 +186,12 @@ class ReadDocumentTool(MCPTool):
             ]
         else:
             if chunk_index >= total_chunks:
-                raise ValueError(
+                raise ToolArgumentValidationError(
                     f"chunk_index {chunk_index} is out of range; "
                     f"document has {total_chunks} chunk(s) of "
-                    f"{chunk_size} characters each."
+                    f"{chunk_size} characters each.",
+                    tool_name=self.name,
+                    argument_names=["chunk_index"],
                 )
             start = chunk_index * chunk_size
             result["chunk_index"] = chunk_index

--- a/courtlistener/mcp/tools/resume_citation_analysis_tool.py
+++ b/courtlistener/mcp/tools/resume_citation_analysis_tool.py
@@ -6,6 +6,7 @@ from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
 from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.mcp.exceptions import SessionDataNotFoundError
 from courtlistener.mcp.session import get_session
 from courtlistener.mcp.tools.citation_utils import (
     MAX_CITATIONS_PER_REQUEST,
@@ -67,8 +68,11 @@ class ResumeCitationAnalysisTool(MCPTool):
         with self.get_client() as client:
             job = await get_session().get_citation_analysis(job_id, client)
             if job is None:
-                raise ValueError(
-                    f"Job ID {job_id!r} not found. The session may have expired."
+                raise SessionDataNotFoundError(
+                    f"Job ID {job_id!r} not found. The session may have "
+                    "expired.",
+                    tool_name=self.name,
+                    argument_name="job_id",
                 )
 
             pending = job["pending"]

--- a/courtlistener/mcp/tools/search_document_tool.py
+++ b/courtlistener/mcp/tools/search_document_tool.py
@@ -3,6 +3,7 @@ import re
 from fastmcp.server.context import Context
 from mcp.types import ToolAnnotations
 
+from courtlistener.mcp.exceptions import ToolArgumentValidationError
 from courtlistener.mcp.tools.mcp_tool import MCPTool
 from courtlistener.mcp.tools.utils import (
     fetch_document_text,
@@ -30,6 +31,8 @@ class SearchDocumentTool(MCPTool):
     When ``match_count`` exceeds ``shown``, the first 20
     matches are returned.  Use ``read_document`` with ``chunk_index`` to
     read the area around a match's ``position`` if you need more context.
+
+    Input should include exactly one of opinion_id, recap_document_id, or cluster_id.
     """
 
     name: str = "search_document"
@@ -164,9 +167,15 @@ class SearchDocumentTool(MCPTool):
             if value is not None
         ]
         if len(provided) != 1:
-            raise ValueError(
+            raise ToolArgumentValidationError(
                 "Provide exactly one of opinion_id, recap_document_id, "
-                "or cluster_id."
+                "or cluster_id.",
+                tool_name=self.name,
+                argument_names=[
+                    "cluster_id",
+                    "opinion_id",
+                    "recap_document_id",
+                ],
             )
 
         query: str = arguments["query"]

--- a/courtlistener/resource.py
+++ b/courtlistener/resource.py
@@ -155,9 +155,11 @@ class Resource:
         return filters
 
     def get(
-        self, id: int | str, fields: list[str] | str | None = None
+        self, id: int | float | str, fields: list[str] | str | None = None
     ) -> dict[str, Any]:
         """Get a resource by its ID."""
+        if isinstance(id, float) and id.is_integer():
+            id = int(id)
         params = {}
         if fields:
             fields = validate_model_fields(self._model, fields)

--- a/courtlistener/utils.py
+++ b/courtlistener/utils.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import TypeAdapter, ValidationInfo
 
+from courtlistener.exceptions import InvalidFieldsError
+
 if TYPE_CHECKING:
     from courtlistener.models import Endpoint
 
@@ -91,7 +93,7 @@ def validate_model_fields(
                     suggestions = "".join(
                         did_you_mean(f, values) for f in invalid_fields
                     )
-                    raise ValueError(
+                    raise InvalidFieldsError(
                         f"Invalid fields: {invalid_fields}.{suggestions}\n"
                         f"Fields must be one of: {values}"
                     )

--- a/docs/mcp/tools/analyze_citations.md
+++ b/docs/mcp/tools/analyze_citations.md
@@ -5,7 +5,7 @@
 **Analyze Citations**
 
 - **Source:** `courtlistener/mcp/tools/analyze_citations_tool.py`
-- **Estimated definition size:** ~445 tokens (description ~213, input schema ~142; cl100k_base)
+- **Estimated definition size:** ~464 tokens (description ~230, input schema ~142; cl100k_base)
 - **Parameters:** 3 (0 required)
 - **Raw input schema:** [`analyze_citations.inputs.json`](./analyze_citations.inputs.json)
 
@@ -34,6 +34,8 @@ Case-name cross-check: when a citation verifies by reporter but
 its input case name differs significantly from the cluster's
 canonical name, a WARNING is emitted flagging a possible
 hallucinated citation.
+
+Input should include exactly one of opinion_id, recap_document_id, or cluster_id.
 
 ## Annotations
 

--- a/docs/mcp/tools/analyze_citations.md
+++ b/docs/mcp/tools/analyze_citations.md
@@ -5,7 +5,7 @@
 **Analyze Citations**
 
 - **Source:** `courtlistener/mcp/tools/analyze_citations_tool.py`
-- **Estimated definition size:** ~464 tokens (description ~230, input schema ~142; cl100k_base)
+- **Estimated definition size:** ~459 tokens (description ~225, input schema ~142; cl100k_base)
 - **Parameters:** 3 (0 required)
 - **Raw input schema:** [`analyze_citations.inputs.json`](./analyze_citations.inputs.json)
 
@@ -35,7 +35,7 @@ its input case name differs significantly from the cluster's
 canonical name, a WARNING is emitted flagging a possible
 hallucinated citation.
 
-Input should include exactly one of opinion_id, recap_document_id, or cluster_id.
+Input should include exactly one of opinion_id or cluster_id.
 
 ## Annotations
 

--- a/docs/mcp/tools/read_document.md
+++ b/docs/mcp/tools/read_document.md
@@ -5,7 +5,7 @@
 **Read Document**
 
 - **Source:** `courtlistener/mcp/tools/read_document_tool.py`
-- **Estimated definition size:** ~558 tokens (description ~227, input schema ~252; cl100k_base)
+- **Estimated definition size:** ~577 tokens (description ~244, input schema ~252; cl100k_base)
 - **Parameters:** 5 (0 required)
 - **Raw input schema:** [`read_document.inputs.json`](./read_document.inputs.json)
 
@@ -31,6 +31,8 @@ uses ``plain_text``.
   non-contiguous windows in a single call (up to
   10).  Useful when you already know the chunk
   size from a previous call and want the next N pages at once.
+
+Input should include exactly one of opinion_id, recap_document_id, or cluster_id.
 
 ## Annotations
 

--- a/docs/mcp/tools/search_document.md
+++ b/docs/mcp/tools/search_document.md
@@ -5,7 +5,7 @@
 **Search Document**
 
 - **Source:** `courtlistener/mcp/tools/search_document_tool.py`
-- **Estimated definition size:** ~531 tokens (description ~170, input schema ~286; cl100k_base)
+- **Estimated definition size:** ~550 tokens (description ~187, input schema ~286; cl100k_base)
 - **Parameters:** 5 (1 required)
 - **Raw input schema:** [`search_document.inputs.json`](./search_document.inputs.json)
 
@@ -26,6 +26,8 @@ unavailable document does not abort the rest.
 When ``match_count`` exceeds ``shown``, the first 20
 matches are returned.  Use ``read_document`` with ``chunk_index`` to
 read the area around a match's ``position`` if you need more context.
+
+Input should include exactly one of opinion_id, recap_document_id, or cluster_id.
 
 ## Annotations
 

--- a/tests/test_get_choices_tool.py
+++ b/tests/test_get_choices_tool.py
@@ -10,6 +10,7 @@ Sentry-exempt error with suggestions.
 
 import pytest
 
+from courtlistener.mcp.exceptions import ToolArgumentValidationError
 from courtlistener.mcp.tools import MCP_TOOLS
 
 
@@ -56,7 +57,7 @@ class TestGetChoices:
 
     @pytest.mark.asyncio
     async def test_unknown_field_errors_with_suggestion(self):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ToolArgumentValidationError) as exc_info:
             await call(
                 endpoint_id="people", field_name="political_affiliation"
             )

--- a/tests/test_mcp_document_ids.py
+++ b/tests/test_mcp_document_ids.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
+from courtlistener.mcp.exceptions import ToolArgumentValidationError
 from courtlistener.mcp.session import InMemorySession, get_session, set_session
 from courtlistener.mcp.tools import MCP_TOOLS
 from courtlistener.mcp.tools.analyze_citations_tool import AnalyzeCitationsTool
@@ -292,7 +293,7 @@ class TestReadDocumentClusterId:
         assert result["text"] == "securities text"
 
     def test_rejects_multiple_id_kinds(self):
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(ToolArgumentValidationError, match="exactly one"):
             run(ReadDocumentTool()({"opinion_id": 1, "cluster_id": 2}, None))
 
     def test_schema_accepts_cluster_id(self):
@@ -376,7 +377,7 @@ class TestSearchDocumentClusterId:
         assert [r["doc_id"] for r in result["results"]] == [10, 11]
 
     def test_rejects_multiple_id_kinds(self):
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(ToolArgumentValidationError, match="exactly one"):
             run(
                 SearchDocumentTool()(
                     {"opinion_id": 1, "cluster_id": 2, "query": "x"}, None
@@ -400,7 +401,7 @@ class TestAnalyzeCitationsClusterId:
         MCP_TOOLS["analyze_citations"].validate_arguments({"cluster_id": 123})
 
     def test_rejects_multiple_id_kinds(self):
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(ToolArgumentValidationError, match="exactly one"):
             run(
                 AnalyzeCitationsTool()(
                     {"opinion_id": 1, "cluster_id": 2}, None

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -123,6 +123,23 @@ class TestMiddlewareErrorClassification:
         assert excinfo.value.status == "connection"
 
     @pytest.mark.asyncio
+    async def test_invalid_fields_maps_to_argument_validation(
+        self, monkeypatch
+    ):
+        """The library's fields check is argument validation the input
+        schema can't express; the middleware reclassifies it so it
+        lands in the tool-argument Sentry issue."""
+        from courtlistener.exceptions import InvalidFieldsError
+        from courtlistener.mcp.exceptions import ToolArgumentValidationError
+
+        error = InvalidFieldsError("Invalid fields: ['case_nam'].")
+        with pytest.raises(ToolArgumentValidationError) as excinfo:
+            await _call_tool_raising(monkeypatch, error)
+        assert excinfo.value.tool_name == "fake_tool"
+        assert excinfo.value.argument_names == ["fields"]
+        assert "case_nam" in str(excinfo.value)
+
+    @pytest.mark.asyncio
     async def test_4xx_stays_plain_tool_error(self, monkeypatch):
         error = _api_error(404, {"detail": "Not found."})
         with pytest.raises(ToolError) as excinfo:
@@ -289,6 +306,45 @@ class TestUnauthorizedFingerprint:
             return event["fingerprint"]
 
         assert fingerprint("search") == fingerprint("analyze_citations")
+
+
+class TestSessionDataFingerprint:
+    """Stale query/job ids get their own issue, separate from the
+    tool-argument bucket: they're usually TTL expiry, and a spike
+    points at Redis/session-store health rather than model behavior.
+    """
+
+    def test_before_send_sets_fingerprint_and_tags(self):
+        from courtlistener.mcp.exceptions import SessionDataNotFoundError
+
+        exc = SessionDataNotFoundError(
+            "Query ID 'abc123' not found.",
+            tool_name="get_more_results",
+            argument_name="query_id",
+        )
+        event = {}
+        result = before_send(event, {"exc_info": (type(exc), exc, None)})
+        assert result is event
+        assert result["fingerprint"] == ["session-data-not-found"]
+        assert result["tags"] == {
+            "tool": "get_more_results",
+            "field": "query_id",
+        }
+
+    def test_query_and_job_ids_share_a_fingerprint(self):
+        from courtlistener.mcp.exceptions import SessionDataNotFoundError
+
+        def fingerprint(tool, argument_name):
+            exc = SessionDataNotFoundError(
+                "not found", tool_name=tool, argument_name=argument_name
+            )
+            event = {}
+            before_send(event, {"exc_info": (type(exc), exc, None)})
+            return event["fingerprint"]
+
+        assert fingerprint("get_counts", "query_id") == fingerprint(
+            "resume_citation_analysis", "job_id"
+        )
 
 
 class TestUpstreamFingerprint:

--- a/tests/test_resource_get.py
+++ b/tests/test_resource_get.py
@@ -1,0 +1,32 @@
+"""Unit tests for `Resource.get` id handling.
+
+JSON clients often send integral floats (5.0) for integer ids; the
+filter path already coerces these via the pydantic endpoint models, so
+`get` matches that tolerance when building the URL.
+"""
+
+from unittest.mock import MagicMock
+
+from courtlistener.models import ENDPOINTS
+from courtlistener.resource import Resource
+
+
+class TestGetIdNormalization:
+    def _requested_path(self, id):
+        client = MagicMock()
+        client._request = MagicMock(return_value={})
+        Resource(client, ENDPOINTS["dockets"]).get(id)
+        return client._request.call_args.args[1]
+
+    def test_integral_float_is_normalized(self):
+        assert self._requested_path(5.0).endswith("/5/")
+
+    def test_int_passes_through(self):
+        assert self._requested_path(5).endswith("/5/")
+
+    def test_str_passes_through(self):
+        assert self._requested_path("scotus").endswith("/scotus/")
+
+    def test_non_integral_float_is_left_alone(self):
+        # Garbage in, garbage out: the API's 404 is the error surface.
+        assert self._requested_path(5.5).endswith("/5.5/")


### PR DESCRIPTION
- Raise `ToolArgumentValidationError` for in-tool argument guards so they share the tool-argument Sentry issue.
- Add `InvalidFieldsError` for invalid `fields` requests, mapped to `ToolArgumentValidationError` in the MCP middleware.
- Add `SessionDataNotFoundError` for stale query/job ids, keyed as its own Sentry issue so spikes surface session-store problems.