### PR TITLE
Prepare API client for async parallel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Changes:
 - Add `SessionDataNotFoundError` for stale query/job ids, keyed as its own Sentry issue so spikes surface session-store problems.
 - Exempt routine token rotation errors from Sentry.
 - Add `idempotentHint` to all MCP tool annotations.
+- Move API client to `sync_client` module.
 
 Fixes:
 - Handle json_schema_extra when it exists but is None.

--- a/courtlistener/__init__.py
+++ b/courtlistener/__init__.py
@@ -1,12 +1,5 @@
-from courtlistener.alerts import DocketAlerts, SearchAlerts
-from courtlistener.citation_lookup import CitationLookup
-from courtlistener.client import CourtListener
-from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.sync_client.client import CourtListener
 
 __all__ = [
-    "CitationLookup",
     "CourtListener",
-    "CourtListenerAPIError",
-    "DocketAlerts",
-    "SearchAlerts",
 ]

--- a/courtlistener/mcp/tools/call_endpoint_tool.py
+++ b/courtlistener/mcp/tools/call_endpoint_tool.py
@@ -80,7 +80,7 @@ class CallEndpointTool(MCPTool):
                     results = collect_results(response, num_results)
                     query_id = await prepare_query_id(response, client)
                     count = prepare_count(
-                        response.current_page.count, query_id
+                        response.get_current_page().count, query_id
                     )
 
                     outputs = {

--- a/courtlistener/mcp/tools/citation_utils.py
+++ b/courtlistener/mcp/tools/citation_utils.py
@@ -22,7 +22,7 @@ from eyecite.models import (
 )
 from eyecite.utils import DISALLOWED_NAMES
 
-from courtlistener.citation_lookup import parse_wait_until
+from courtlistener.sync_client.citation_lookup import parse_wait_until
 
 # Delimiter used between citations in the compact string sent to the
 # citation-lookup API.  Semicolon-space is a natural Bluebook list

--- a/courtlistener/mcp/tools/get_counts_tool.py
+++ b/courtlistener/mcp/tools/get_counts_tool.py
@@ -46,5 +46,5 @@ class GetCountsTool(MCPTool):
                     "expired, please redo the query first."
                 )
             response = ResourceIterator.load(client, data["response"])
-            count = response.count
+            count = response.get_count()
             return {"count": count}

--- a/courtlistener/mcp/tools/get_counts_tool.py
+++ b/courtlistener/mcp/tools/get_counts_tool.py
@@ -3,7 +3,7 @@ from mcp.types import ToolAnnotations
 
 from courtlistener.mcp.session import get_session
 from courtlistener.mcp.tools.mcp_tool import MCPTool
-from courtlistener.resource import ResourceIterator
+from courtlistener.sync_client.resource import ResourceIterator
 
 
 class GetCountsTool(MCPTool):

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -14,7 +14,7 @@ from courtlistener.mcp.tools.utils import (
     has_more_results,
     prepare_has_more_str,
 )
-from courtlistener.resource import ResourceIterator
+from courtlistener.sync_client.resource import ResourceIterator
 
 
 class GetMoreResultsTool(MCPTool):

--- a/courtlistener/mcp/tools/search_tool.py
+++ b/courtlistener/mcp/tools/search_tool.py
@@ -111,7 +111,7 @@ class SearchTool(MCPTool):
             add_opinion_ids(results)
 
             query_id = await prepare_query_id(response, client, fields=fields)
-            count = prepare_count(response.current_page.count, query_id)
+            count = prepare_count(response.get_current_page().count, query_id)
             filtered_results, missing_fields = filter_results_by_fields(
                 results, fields
             )

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -9,7 +9,7 @@ from courtlistener import CourtListener
 from courtlistener.mcp.session import get_session
 from courtlistener.mcp.settings import DEFAULT_NUM_RESULTS
 from courtlistener.models import ENDPOINTS
-from courtlistener.resource import ResourceIterator
+from courtlistener.sync_client.resource import ResourceIterator
 
 logger = logging.getLogger(__name__)
 

--- a/courtlistener/mcp/tools/utils.py
+++ b/courtlistener/mcp/tools/utils.py
@@ -177,7 +177,7 @@ def prepare_count(count: int | str | None, query_id: str) -> int | str | None:
 
 def has_more_results(response: ResourceIterator) -> bool:
     """Check whether a ResourceIterator has unconsumed results."""
-    page = response.current_page
+    page = response.get_current_page()
     if response._page_result_index < len(page.results):
         return True
     return response.has_next()

--- a/courtlistener/models/alerts.py
+++ b/courtlistener/models/alerts.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+from urllib.parse import parse_qs, urlencode
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict
+
+from courtlistener.utils import (
+    flatten_filters,
+    search_model_validator,
+    unflatten_filters,
+)
+
+RateType = Literal["rt", "dly", "wly", "mly", "off"]
+SearchAlertType = Literal["o", "r", "d", "oa"]
+DocketAlertType = Literal[0, 1]
+
+
+def normalize_search_query(query: str | dict[str, Any] | None) -> str | None:
+    """Normalize and validate a search query, returning a URL query string."""
+    if query is None:
+        return None
+    if isinstance(query, str):
+        parsed = parse_qs(query, keep_blank_values=True)
+        params = {k: v[0] if len(v) == 1 else v for k, v in parsed.items()}
+    else:
+        params = dict(query)
+
+    params = unflatten_filters(params)
+    params.setdefault("type", "o")
+    validated = search_model_validator(params)
+    flat = flatten_filters(validated)
+    flat = {k: v for k, v in flat.items() if v is not None}
+
+    return urlencode(flat, doseq=True)
+
+
+class SearchAlertCreate(BaseModel):
+    """Validation model for creating a search alert."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    query: Annotated[
+        str | dict[str, Any] | None,
+        BeforeValidator(normalize_search_query),
+    ]
+    rate: RateType
+    alert_type: SearchAlertType | None = None
+
+
+class SearchAlertUpdate(BaseModel):
+    """Validation model for updating a search alert."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    query: Annotated[
+        str | dict[str, Any] | None,
+        BeforeValidator(normalize_search_query),
+    ] = None
+    rate: RateType | None = None
+    alert_type: SearchAlertType | None = None
+
+
+class DocketAlertCreate(BaseModel):
+    """Validation model for creating a docket alert."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    docket: int
+    alert_type: DocketAlertType = 1
+
+
+class DocketAlertUpdate(BaseModel):
+    """Validation model for updating a docket alert."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    alert_type: DocketAlertType | None = None

--- a/courtlistener/sync_client/__init__.py
+++ b/courtlistener/sync_client/__init__.py
@@ -1,0 +1,13 @@
+from courtlistener.sync_client.alerts import DocketAlerts, SearchAlerts
+from courtlistener.sync_client.citation_lookup import CitationLookup
+from courtlistener.sync_client.client import CourtListener
+from courtlistener.sync_client.resource import Resource, ResourceIterator
+
+__all__ = [
+    "CitationLookup",
+    "CourtListener",
+    "DocketAlerts",
+    "Resource",
+    "ResourceIterator",
+    "SearchAlerts",
+]

--- a/courtlistener/sync_client/alerts.py
+++ b/courtlistener/sync_client/alerts.py
@@ -1,107 +1,24 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
-from urllib.parse import parse_qs, urlencode
+from typing import TYPE_CHECKING, Any, cast
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict
-
+from courtlistener.models.alerts import (
+    DocketAlertCreate,
+    DocketAlertType,
+    DocketAlertUpdate,
+    RateType,
+    SearchAlertCreate,
+    SearchAlertType,
+    SearchAlertUpdate,
+)
 from courtlistener.models.endpoints.alerts import AlertsEndpoint
 from courtlistener.models.endpoints.docket_alerts import (
     DocketAlertsEndpoint,
 )
-from courtlistener.resource import Resource
-from courtlistener.utils import (
-    flatten_filters,
-    search_model_validator,
-    unflatten_filters,
-)
+from courtlistener.sync_client.resource import Resource
 
 if TYPE_CHECKING:
-    from courtlistener.client import CourtListener
-
-# ---------------------------------------------------------------------------
-# Pydantic models for create/update validation
-# ---------------------------------------------------------------------------
-
-RateType = Literal["rt", "dly", "wly", "mly", "off"]
-SearchAlertType = Literal["o", "r", "d", "oa"]
-DocketAlertType = Literal[0, 1]
-
-
-def normalize_search_query(query: str | dict[str, Any] | None) -> str | None:
-    """Normalize and validate a search query, returning a URL query string.
-
-    Accepts either a URL query string (e.g. ``"q=test&court=scotus"``)
-    or a structured dict (e.g. ``{"q": "test", "court": "scotus"}``).
-    In both cases the query is validated against the ``SearchEndpoint``
-    model via ``search_model_validator`` and serialized back to a
-    canonical query string.
-    """
-    if query is None:
-        return None
-    if isinstance(query, str):
-        parsed = parse_qs(query, keep_blank_values=True)
-        params = {k: v[0] if len(v) == 1 else v for k, v in parsed.items()}
-    else:
-        params = dict(query)
-
-    params = unflatten_filters(params)
-    params.setdefault("type", "o")
-    validated = search_model_validator(params)
-    flat = flatten_filters(validated)
-    flat = {k: v for k, v in flat.items() if v is not None}
-
-    return urlencode(flat, doseq=True)
-
-
-class SearchAlertCreate(BaseModel):
-    """Validation model for creating a search alert."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    name: str
-    query: Annotated[
-        str | dict[str, Any] | None,
-        BeforeValidator(normalize_search_query),
-    ]
-    rate: RateType
-    alert_type: SearchAlertType | None = None
-
-
-class SearchAlertUpdate(BaseModel):
-    """Validation model for updating a search alert."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    name: str | None = None
-    query: Annotated[
-        str | dict[str, Any] | None,
-        BeforeValidator(normalize_search_query),
-    ] = None
-    rate: RateType | None = None
-    alert_type: SearchAlertType | None = None
-
-
-class DocketAlertCreate(BaseModel):
-    """Validation model for creating a docket alert."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    docket: int
-    alert_type: DocketAlertType = 1
-
-
-class DocketAlertUpdate(BaseModel):
-    """Validation model for updating a docket alert."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    alert_type: DocketAlertType | None = None
-
-
-# ---------------------------------------------------------------------------
-# Resource subclasses
-# ---------------------------------------------------------------------------
+    from courtlistener.sync_client.client import CourtListener
 
 
 class SearchAlerts(Resource):

--- a/courtlistener/sync_client/citation_lookup.py
+++ b/courtlistener/sync_client/citation_lookup.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from courtlistener.exceptions import CourtListenerAPIError
 
 if TYPE_CHECKING:
-    from courtlistener.client import CourtListener
+    from courtlistener.sync_client.client import CourtListener
 
 MAX_TEXT_LENGTH = 64_000
 THROTTLE_STATUS = 429

--- a/courtlistener/sync_client/client.py
+++ b/courtlistener/sync_client/client.py
@@ -7,11 +7,11 @@ import httpx
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.models import ENDPOINTS
-from courtlistener.resource import Resource
+from courtlistener.sync_client.resource import Resource
 
 if TYPE_CHECKING:
-    from courtlistener.alerts import DocketAlerts, SearchAlerts
-    from courtlistener.citation_lookup import CitationLookup
+    from courtlistener.sync_client.alerts import DocketAlerts, SearchAlerts
+    from courtlistener.sync_client.citation_lookup import CitationLookup
 
 DEFAULT_API_BASE_URL = "https://www.courtlistener.com/api/rest/v4"
 
@@ -65,7 +65,7 @@ class CourtListener:
     def alerts(self) -> SearchAlerts:
         """Access the search alerts API."""
         if not hasattr(self, "_alerts"):
-            from courtlistener.alerts import SearchAlerts
+            from courtlistener.sync_client.alerts import SearchAlerts
 
             self._alerts = SearchAlerts(self)
         return self._alerts
@@ -74,7 +74,7 @@ class CourtListener:
     def docket_alerts(self) -> DocketAlerts:
         """Access the docket alerts API."""
         if not hasattr(self, "_docket_alerts"):
-            from courtlistener.alerts import DocketAlerts
+            from courtlistener.sync_client.alerts import DocketAlerts
 
             self._docket_alerts = DocketAlerts(self)
         return self._docket_alerts
@@ -83,7 +83,9 @@ class CourtListener:
     def citation_lookup(self) -> CitationLookup:
         """Access the citation lookup and verification API."""
         if not hasattr(self, "_citation_lookup"):
-            from courtlistener.citation_lookup import CitationLookup
+            from courtlistener.sync_client.citation_lookup import (
+                CitationLookup,
+            )
 
             self._citation_lookup = CitationLookup(self)
         return self._citation_lookup

--- a/courtlistener/sync_client/resource.py
+++ b/courtlistener/sync_client/resource.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
@@ -43,8 +44,7 @@ class ResourceIterator:
             )
         return Page(**data)
 
-    @property
-    def current_page(self) -> Page:
+    def get_current_page(self) -> Page:
         """Get the current page."""
         if self._current_page is None:
             self._current_page = self._fetch_page()
@@ -52,46 +52,49 @@ class ResourceIterator:
 
     def has_next(self) -> bool:
         """Whether there is a next page."""
-        return self.current_page.next is not None
+        return self.get_current_page().next is not None
 
     def has_previous(self) -> bool:
         """Whether there is a previous page."""
-        return self.current_page.previous is not None
+        return self.get_current_page().previous is not None
 
     def next(self) -> None:
         """Get the next page."""
         if not self.has_next():
             raise ValueError("No next page")
-        self._current_page = self._fetch_page(self.current_page.next)
+        current_page = self.get_current_page()
+        self._current_page = self._fetch_page(current_page.next)
         self._page_result_index = 0
 
     def previous(self) -> None:
         """Get the previous page."""
         if not self.has_previous():
             raise ValueError("No previous page")
-        self._current_page = self._fetch_page(self.current_page.previous)
+        current_page = self.get_current_page()
+        self._current_page = self._fetch_page(current_page.previous)
         self._page_result_index = 0
 
     def __iter__(self) -> Iterator[dict[str, Any]]:
         """Iterate over all results across pages, respecting the page result index."""
         while True:
-            for item in self.current_page.results[self._page_result_index :]:
+            current_page = self.get_current_page()
+            for item in current_page.results[self._page_result_index :]:
                 self._page_result_index += 1
                 yield item
             if not self.has_next():
                 break
             self.next()
 
-    @property
-    def count(self) -> int:
+    def get_count(self) -> int:
         """Total count of results across all pages."""
         if self._count is None:
-            if self.current_page.count is None:
+            current_page = self.get_current_page()
+            if current_page.count is None:
                 raise ValueError("No count URL")
-            elif isinstance(self.current_page.count, int):
-                self._count = self.current_page.count
+            elif isinstance(current_page.count, int):
+                self._count = current_page.count
             else:
-                parsed = urlparse(self.current_page.count)
+                parsed = urlparse(current_page.count)
                 path = parsed.path
                 if parsed.query:
                     path = f"{path}?{parsed.query}"
@@ -99,22 +102,22 @@ class ResourceIterator:
                 self._count = int(data.get("count", 0))
         return self._count
 
-    @property
-    def document_count(self) -> int | None:
+    def get_document_count(self) -> int | None:
         """Total count of nested documents for recap search endpoint."""
-        if self.current_page is not None:
-            return self.current_page.document_count
+        current_page = self.get_current_page()
+        if current_page is not None:
+            return current_page.document_count
         return None
 
-    @property
-    def results(self) -> list[dict[str, Any]]:
+    def get_results(self) -> list[dict[str, Any]]:
         """Results from the current page."""
-        return self.current_page.results
+        return self.get_current_page().results
 
     def dump(self) -> dict[str, Any]:
         """Serialize the iterator state to a dict for later restoration."""
+        current_page = self.get_current_page()
         return {
-            "current_page": self.current_page.model_dump(),
+            "current_page": current_page.model_dump(),
             "filters": self._filters,
             "endpoint": self._endpoint,
             "page_result_index": self._page_result_index,
@@ -134,6 +137,46 @@ class ResourceIterator:
         iterator._page_result_index = data["page_result_index"]
         iterator._count = data["count"]
         return iterator
+
+    # ------------------------------------------------------------------
+    # Deprecated property aliases.
+    #
+    # Kept only for backwards compatibility with pre-async-split code;
+    # they do not exist on AsyncResourceIterator and will not survive
+    # the planned unasync code generation. Use the get_* methods.
+    # ------------------------------------------------------------------
+
+    def _warn_deprecated(self, name: str) -> None:
+        warnings.warn(
+            f"ResourceIterator.{name} is deprecated and will be removed "
+            f"in a future release; use get_{name}() instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+    @property
+    def current_page(self) -> Page:
+        """Deprecated alias for :meth:`get_current_page`."""
+        self._warn_deprecated("current_page")
+        return self.get_current_page()
+
+    @property
+    def count(self) -> int:
+        """Deprecated alias for :meth:`get_count`."""
+        self._warn_deprecated("count")
+        return self.get_count()
+
+    @property
+    def document_count(self) -> int | None:
+        """Deprecated alias for :meth:`get_document_count`."""
+        self._warn_deprecated("document_count")
+        return self.get_document_count()
+
+    @property
+    def results(self) -> list[dict[str, Any]]:
+        """Deprecated alias for :meth:`get_results`."""
+        self._warn_deprecated("results")
+        return self.get_results()
 
 
 class Resource:

--- a/courtlistener/sync_client/resource.py
+++ b/courtlistener/sync_client/resource.py
@@ -8,7 +8,7 @@ from courtlistener.models import Endpoint, Page
 from courtlistener.utils import flatten_filters, validate_model_fields
 
 if TYPE_CHECKING:
-    from courtlistener.client import CourtListener
+    from courtlistener.sync_client.client import CourtListener
 
 
 class ResourceIterator:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ urls.Repository = "https://github.com/freelawproject/courtlistener-api-client"
 urls."Organisation Homepage" = "https://free.law/"
 
 dependencies = [
+    "anyio>=4.0.0",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def client():
 
 def first_result_id(results):
     """Extract the ID from the first result in a ResourceIterator."""
-    if results.results:
-        result = results.results[0]
+    if results.get_results():
+        result = results.get_results()[0]
         return result.get("id") or result.get("resource_uri")
     return None

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -8,12 +8,9 @@ import httpx
 import pytest
 from pydantic import ValidationError
 
-from courtlistener.alerts import (
-    DocketAlerts,
-    SearchAlerts,
-    normalize_search_query,
-)
 from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.models.alerts import normalize_search_query
+from courtlistener.sync_client.alerts import DocketAlerts, SearchAlerts
 
 # ---------------------------------------------------------------------------
 # Unit tests – normalize_search_query

--- a/tests/test_citation_lookup.py
+++ b/tests/test_citation_lookup.py
@@ -4,7 +4,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from courtlistener.citation_lookup import CitationLookup, _split_text
+from courtlistener.sync_client.citation_lookup import (
+    CitationLookup,
+    _split_text,
+)
 
 
 @pytest.mark.integration

--- a/tests/test_dockets.py
+++ b/tests/test_dockets.py
@@ -17,47 +17,47 @@ class TestDocketsList:
     def test_list_with_court_filter(self, client):
         """Filter by court using the short code."""
         results = client.dockets.list(court="scotus")
-        assert len(results.results) > 0
-        for docket in results.results:
+        assert len(results.get_results()) > 0
+        for docket in results.get_results():
             assert docket["court"].endswith("/courts/scotus/")
 
     def test_list_with_date_filter(self, client):
         """Nested date filter dict gets flattened to query params."""
         results = client.dockets.list(date_filed={"gte": "2020-01-01"})
-        assert len(results.results) > 0
-        for docket in results.results:
+        assert len(results.get_results()) > 0
+        for docket in results.get_results():
             filed = date.fromisoformat(docket["date_filed"])
             assert filed >= date(2020, 1, 1)
 
     def test_list_with_source_in_filter(self, client):
         """In-filter pipeline: list of ints → source__in=0,1."""
         results = client.dockets.list(source=[0, 1])
-        assert isinstance(results.results, list)
-        for docket in results.results:
+        assert isinstance(results.get_results(), list)
+        for docket in results.get_results():
             assert docket["source"] in (0, 1)
 
         results = client.dockets.list(source__in=[0, 1])
-        assert isinstance(results.results, list)
-        for docket in results.results:
+        assert isinstance(results.get_results(), list)
+        for docket in results.get_results():
             assert docket["source"] in (0, 1)
 
         results = client.dockets.list(source__in="0,1")
-        assert isinstance(results.results, list)
-        for docket in results.results:
+        assert isinstance(results.get_results(), list)
+        for docket in results.get_results():
             assert docket["source"] in (0, 1)
 
     def test_list_with_source_display_name(self, client):
         """Source choice by display name resolves to int value."""
         results = client.dockets.list(source="RECAP")
-        assert len(results.results) > 0
-        for docket in results.results:
+        assert len(results.get_results()) > 0
+        for docket in results.get_results():
             assert docket["source"] == 1  # RECAP = 1
 
     def test_list_with_nature_of_suit_filter(self, client):
         """String filter with 'startswith' lookup."""
         results = client.dockets.list(nature_of_suit={"startswith": "440"})
-        assert isinstance(results.results, list)
-        for docket in results.results:
+        assert isinstance(results.get_results(), list)
+        for docket in results.get_results():
             assert docket["nature_of_suit"].startswith("440")
 
     def test_list_with_date_range(self, client):
@@ -68,21 +68,21 @@ class TestDocketsList:
                 "lte": "2026-01-30",
             }
         )
-        assert len(results.results) > 0
-        for docket in results.results:
+        assert len(results.get_results()) > 0
+        for docket in results.get_results():
             filed = date.fromisoformat(docket["date_filed"])
             assert date(2026, 1, 1) <= filed <= date(2026, 1, 30)
 
     def test_list_with_fields_filter(self, client):
         """Date filter with both gte and lte."""
         results = client.dockets.list(fields="id,court")
-        assert len(results.results) > 0
-        for docket in results.results:
+        assert len(results.get_results()) > 0
+        for docket in results.get_results():
             assert all(k in ["id", "court"] for k in docket)
 
         results = client.dockets.list(fields=["id", "court"])
-        assert len(results.results) > 0
-        for docket in results.results:
+        assert len(results.get_results()) > 0
+        for docket in results.get_results():
             assert all(k in ["id", "court"] for k in docket)
 
 
@@ -96,9 +96,9 @@ class TestDocketsGet:
         and intermittently 504s when CourtListener is under load.
         """
         results = client.dockets.list(court="scotus", fields=["id"])
-        assert results.results, "Need at least one docket"
+        assert results.get_results(), "Need at least one docket"
 
-        docket_id = results.results[0]["id"]
+        docket_id = results.get_results()[0]["id"]
         docket = client.dockets.get(docket_id)
 
         assert isinstance(docket, dict)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -52,7 +52,7 @@ class TestEndpointList:
         results = resource.list()
 
         assert isinstance(results, ResourceIterator)
-        assert isinstance(results.results, list)
+        assert isinstance(results.get_results(), list)
 
 
 @pytest.mark.integration
@@ -68,10 +68,10 @@ class TestEndpointGet:
         resource = getattr(client, endpoint_name)
         results = resource.list()
 
-        if not results.results:
+        if not results.get_results():
             pytest.skip(f"No results for {endpoint_name}, can't test .get()")
 
-        first = results.results[0]
+        first = results.get_results()[0]
         item_id = first.get("id")
         if item_id is None:
             pytest.skip(f"First result for {endpoint_name} has no 'id' field")

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -16,7 +16,7 @@ Some endpoints are special-cased:
 import pytest
 
 from courtlistener.models import ENDPOINTS
-from courtlistener.resource import ResourceIterator
+from courtlistener.sync_client.resource import ResourceIterator
 
 # Endpoints that don't support GET list (POST-only, write-only, or
 # require special parameters).

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from courtlistener import CourtListener, CourtListenerAPIError
+from courtlistener import CourtListener
+from courtlistener.exceptions import CourtListenerAPIError
 
 
 @pytest.fixture

--- a/tests/test_mcp_document_ids.py
+++ b/tests/test_mcp_document_ids.py
@@ -38,6 +38,9 @@ class FakeIterator:
         )
         self._page_result_index = len(self._results)
 
+    def get_current_page(self):
+        return self.current_page
+
     def __iter__(self):
         return iter(self._results)
 

--- a/tests/test_opinions.py
+++ b/tests/test_opinions.py
@@ -11,8 +11,8 @@ class TestOpinions:
     def test_list(self, client):
         """Opinions list returns results with expected fields."""
         results = client.opinions.list()
-        assert len(results.results) > 0
-        for opinion in results.results:
+        assert len(results.get_results()) > 0
+        for opinion in results.get_results():
             assert "id" in opinion
             assert "type" in opinion
             assert "cluster" in opinion
@@ -20,7 +20,7 @@ class TestOpinions:
     def test_get_by_id(self, client):
         """Get a single opinion and verify it matches the list."""
         results = client.opinions.list()
-        first = results.results[0]
+        first = results.get_results()[0]
 
         opinion = client.opinions.get(first["id"])
 
@@ -36,8 +36,8 @@ class TestClusters:
     def test_list(self, client):
         """Clusters list returns results with expected fields."""
         results = client.clusters.list()
-        assert len(results.results) > 0
-        for cluster in results.results:
+        assert len(results.get_results()) > 0
+        for cluster in results.get_results():
             assert "id" in cluster
             assert "case_name" in cluster
             assert "docket" in cluster
@@ -46,7 +46,7 @@ class TestClusters:
     def test_get_by_id(self, client):
         """Get a single cluster and verify it matches the list."""
         results = client.clusters.list()
-        first = results.results[0]
+        first = results.get_results()[0]
 
         cluster = client.clusters.get(first["id"])
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,6 +1,19 @@
-"""Hand-written tests for pagination behavior on a real endpoint."""
+"""Tests for pagination behavior: integration plus deprecation shims."""
+
+import warnings
+from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 import pytest
+
+from courtlistener import CourtListener
+
+
+@contextmanager
+def warnings_as_errors():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        yield
 
 
 @pytest.mark.integration
@@ -8,7 +21,7 @@ class TestPagination:
     def test_first_page_has_results(self, client):
         """Courts endpoint returns a first page with results."""
         results = client.courts.list()
-        assert len(results.results) > 0
+        assert len(results.get_results()) > 0
 
     def test_has_next(self, client):
         """Endpoints with multiple pages should have a next page."""
@@ -18,17 +31,17 @@ class TestPagination:
     def test_next_page(self, client):
         """Calling next() fetches a different page of results."""
         results = client.courts.list()
-        first_page_ids = [r["id"] for r in results.results]
+        first_page_ids = [r["id"] for r in results.get_results()]
 
         results.next()
-        second_page_ids = [r["id"] for r in results.results]
+        second_page_ids = [r["id"] for r in results.get_results()]
 
         assert second_page_ids != first_page_ids
 
     def test_count(self, client):
         """Count returns a positive integer."""
         results = client.courts.list()
-        count = results.count
+        count = results.get_count()
         assert isinstance(count, int)
         assert count > 0
 
@@ -51,3 +64,58 @@ class TestPagination:
 
         with pytest.raises(ValueError, match="No previous page"):
             results.previous()
+
+
+def _iterator(pages):
+    cl = CourtListener(api_token="tok")
+    cl._request = MagicMock(side_effect=pages)
+    return cl.courts.list()
+
+
+def _page(results, count=None):
+    return {
+        "count": count if count is not None else len(results),
+        "next": None,
+        "previous": None,
+        "results": results,
+    }
+
+
+class TestDeprecatedProperties:
+    """The property accessors are backwards-compat shims for the
+    ``get_*`` methods and warn on use."""
+
+    @pytest.mark.parametrize(
+        "prop,method",
+        [
+            ("current_page", "get_current_page"),
+            ("count", "get_count"),
+            ("document_count", "get_document_count"),
+            ("results", "get_results"),
+        ],
+    )
+    def test_property_warns_and_matches_method(self, prop, method):
+        it = _iterator([_page([{"id": 1}], count=7)])
+        with pytest.warns(DeprecationWarning, match=f"use {method}\\(\\)"):
+            via_property = getattr(it, prop)
+        assert via_property == getattr(it, method)()
+
+    def test_methods_do_not_warn(self):
+        it = _iterator([_page([{"id": 1}], count=7)])
+        with warnings_as_errors():
+            assert it.get_results() == [{"id": 1}]
+            assert it.get_count() == 7
+            assert it.get_current_page().results == [{"id": 1}]
+            assert it.get_document_count() is None
+
+    def test_iteration_does_not_warn(self):
+        """Internal code paths use the methods, not the shims."""
+        it = _iterator([_page([{"id": 1}, {"id": 2}])])
+        with warnings_as_errors():
+            assert [item["id"] for item in it] == [1, 2]
+
+    def test_dump_does_not_warn(self):
+        it = _iterator([_page([{"id": 1}])])
+        with warnings_as_errors():
+            state = it.dump()
+        assert state["page_result_index"] == 0

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,12 +15,12 @@ class TestSearch:
     def test_search_opinions_via_opinion_search(self, client):
         """Opinion search returns opinion results."""
         results = client.opinion_search.list(q="Miranda")
-        assert len(results.results) > 0
+        assert len(results.get_results()) > 0
 
     def test_search_recap_via_recap_search(self, client):
         """Recap search returns recap results."""
         results = client.recap_search.list(q="motion")
-        assert len(results.results) > 0
+        assert len(results.get_results()) > 0
 
 
 @pytest.mark.integration
@@ -28,13 +28,13 @@ class TestOpinionSearch:
     def test_basic_query(self, client):
         """Opinion search with a query string."""
         results = client.opinion_search.list(q="copyright")
-        assert len(results.results) > 0
+        assert len(results.get_results()) > 0
 
     def test_with_court_filter(self, client):
         """Opinion search filtered to SCOTUS returns only SCOTUS."""
         results = client.opinion_search.list(q="copyright", court="scotus")
-        assert len(results.results) > 0
-        for result in results.results:
+        assert len(results.get_results()) > 0
+        for result in results.get_results():
             assert result["court_id"] == "scotus"
 
     def test_multi_court_filter(self, client):
@@ -42,16 +42,16 @@ class TestOpinionSearch:
         results = client.opinion_search.list(
             q="patent", court=["scotus", "cafc"]
         )
-        assert len(results.results) > 0
-        for result in results.results:
+        assert len(results.get_results()) > 0
+        for result in results.get_results():
             assert result["court_id"] in ("scotus", "cafc")
 
     def test_relative_date_filed_after(self, client):
         """Relative date string filters results correctly."""
         results = client.opinion_search.list(q="tax", filed_after="1 year ago")
-        assert len(results.results) > 0
+        assert len(results.get_results()) > 0
         one_year_ago = date.today() - timedelta(days=365)
-        for result in results.results:
+        for result in results.get_results():
             filed = date.fromisoformat(result["dateFiled"])
             assert filed >= one_year_ago
 
@@ -60,9 +60,9 @@ class TestOpinionSearch:
         results = client.opinion_search.list(
             q="tax", filed_before="6 months ago"
         )
-        assert len(results.results) > 0
+        assert len(results.get_results()) > 0
         six_months_ago = date.today() - timedelta(days=180)
-        for result in results.results:
+        for result in results.get_results():
             filed = date.fromisoformat(result["dateFiled"])
             assert filed <= six_months_ago
 
@@ -72,11 +72,11 @@ class TestRecapSearch:
     def test_basic_query(self, client):
         """Recap search returns results."""
         results = client.recap_search.list(q="bankruptcy")
-        assert len(results.results) > 0
+        assert len(results.get_results()) > 0
 
     def test_document_count(self, client):
         """Recap search exposes document_count."""
         results = client.recap_search.list(q="bankruptcy")
         # document_count may or may not be present depending on API
         # but accessing it should not error
-        _ = results.document_count
+        _ = results.get_document_count()

--- a/uv.lock
+++ b/uv.lock
@@ -357,6 +357,7 @@ name = "courtlistener-api-client"
 version = "1.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
@@ -387,6 +388,7 @@ mcp = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.0.0" },
     { name = "click", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "eyecite", marker = "extra == 'mcp'", specifier = ">=2.6.0" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = "==3.4.0" },


### PR DESCRIPTION
Related to #222 

This PR does a few things to prepare for the async version of the client:
- It moves the sync client to a dedicated module
- Shared utilities are kept at the root of the package
- Alerts models are moved to the models dir (probably where they should have been already)
- Property decorated methods are depreciated. Kept with a depreciation warning but replaced in usage by a parallel set of regular methods (this way we can have a 1-1 mapping between these methods and their awaitable analogues). Old `@property` methods are no longer used within the package, left solely for backwards compatibility.
- Top level package exports only the client. Resource, alerts, and citation classes are left as internal classes.

The plan is to ultimately create an async client that will be nearly 1-1 with the sync client so that we can implement a code-gen script that mostly leans on unasync to keep the two in sync.