### PR TITLE
Add async client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,12 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
+        - "3.10"
+        - "3.11"
+        - "3.12"
         - "3.13"
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 The following changes are not yet released, but are code complete:
 
+### 1.2.0 - 2026-08-04
+
 Features:
 - Add support for cluster_id in search_document, read_document, and analyze_citations tools.
 - Add support for space or comma-separated values for multiple-choice fields and `fields` field.
@@ -23,7 +25,9 @@ Changes:
 - Add `SessionDataNotFoundError` for stale query/job ids, keyed as its own Sentry issue so spikes surface session-store problems.
 - Exempt routine token rotation errors from Sentry.
 - Add `idempotentHint` to all MCP tool annotations.
-- Move API client to `sync_client` module.
+- Move API client to `sync_client` module. All previously top-level names remain importable from `courtlistener`, alongside their async counterparts.
+- Deprecate the `ResourceIterator` properties `current_page`, `count`, `document_count`, and `results` in favor of `get_current_page()`, `get_count()`, `get_document_count()`, and `get_results()`. The properties still work but emit a `DeprecationWarning`; the methods have awaitable analogues on `AsyncResourceIterator`.
+- Test against Python 3.10 through 3.13 in CI.
 
 Fixes:
 - Handle json_schema_extra when it exists but is None.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Features:
 - Add support for related fields that don't have a schema.
 - Add near-miss suggestions to invalid-choice errors.
 - Better response when a model uses `get_choices` tool on a non-choice field.
+- Add `AsyncCourtListener` client for asynchronous API operations.
 
 Changes:
 - Improve global prompt to clarify that cluster_id is a separate id-space from opinion_id.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ opinion = client.opinions.get(1)
 response = client.opinions.list(cluster__case_name="Miranda")
 
 # Access results from the current page
-for opinion in response.results:
+for opinion in response.get_results():
     print(opinion)
 
 # Check the total count of matching results
-print(response.count)
+print(response.get_count())
 
 # Iterate through all results across pages
 response = client.dockets.list(court="scotus")
@@ -67,11 +67,11 @@ for docket in results:
 
 # Or navigate pages manually
 results = client.dockets.list(court="scotus")
-print(results.results)   # current page results
+print(results.get_results())   # current page results
 
 if results.has_next():
     results.next()
-    print(results.results)  # next page results
+    print(results.get_results())  # next page results
 ```
 
 ## Available Endpoints
@@ -105,3 +105,20 @@ Access any endpoint as an attribute on the client. Each endpoint supports `.get(
 | `fjc_integrated_database` | FJC integrated database |
 
 See the [CourtListener API docs](https://www.courtlistener.com/api/rest-info/) for the full list and available filters.
+
+## Async
+
+`AsyncCourtListener` mirrors `CourtListener` method for method. Anything that
+makes a request is awaited, iteration uses `async for`, and the client is an
+async context manager.
+
+```python
+from courtlistener import AsyncCourtListener
+
+async with AsyncCourtListener() as client:
+    opinion = await client.opinions.get(1)
+
+    results = client.dockets.list(court="scotus")
+    async for docket in results:
+        print(docket)
+```

--- a/courtlistener/__init__.py
+++ b/courtlistener/__init__.py
@@ -1,5 +1,7 @@
+from courtlistener.async_client.client import AsyncCourtListener
 from courtlistener.sync_client.client import CourtListener
 
 __all__ = [
+    "AsyncCourtListener",
     "CourtListener",
 ]

--- a/courtlistener/__init__.py
+++ b/courtlistener/__init__.py
@@ -1,7 +1,32 @@
+from courtlistener.async_client.alerts import (
+    AsyncDocketAlerts,
+    AsyncSearchAlerts,
+)
+from courtlistener.async_client.citation_lookup import AsyncCitationLookup
 from courtlistener.async_client.client import AsyncCourtListener
+from courtlistener.async_client.resource import (
+    AsyncResource,
+    AsyncResourceIterator,
+)
+from courtlistener.exceptions import CourtListenerAPIError, InvalidFieldsError
+from courtlistener.sync_client.alerts import DocketAlerts, SearchAlerts
+from courtlistener.sync_client.citation_lookup import CitationLookup
 from courtlistener.sync_client.client import CourtListener
+from courtlistener.sync_client.resource import Resource, ResourceIterator
 
 __all__ = [
+    "AsyncCitationLookup",
     "AsyncCourtListener",
+    "AsyncDocketAlerts",
+    "AsyncResource",
+    "AsyncResourceIterator",
+    "AsyncSearchAlerts",
+    "CitationLookup",
     "CourtListener",
+    "CourtListenerAPIError",
+    "DocketAlerts",
+    "InvalidFieldsError",
+    "Resource",
+    "ResourceIterator",
+    "SearchAlerts",
 ]

--- a/courtlistener/async_client/__init__.py
+++ b/courtlistener/async_client/__init__.py
@@ -1,0 +1,19 @@
+from courtlistener.async_client.alerts import (
+    AsyncDocketAlerts,
+    AsyncSearchAlerts,
+)
+from courtlistener.async_client.citation_lookup import AsyncCitationLookup
+from courtlistener.async_client.client import AsyncCourtListener
+from courtlistener.async_client.resource import (
+    AsyncResource,
+    AsyncResourceIterator,
+)
+
+__all__ = [
+    "AsyncCitationLookup",
+    "AsyncCourtListener",
+    "AsyncDocketAlerts",
+    "AsyncResource",
+    "AsyncResourceIterator",
+    "AsyncSearchAlerts",
+]

--- a/courtlistener/async_client/alerts.py
+++ b/courtlistener/async_client/alerts.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from courtlistener.async_client.resource import AsyncResource
+from courtlistener.models.alerts import (
+    DocketAlertCreate,
+    DocketAlertType,
+    DocketAlertUpdate,
+    RateType,
+    SearchAlertCreate,
+    SearchAlertType,
+    SearchAlertUpdate,
+)
+from courtlistener.models.endpoints.alerts import AlertsEndpoint
+from courtlistener.models.endpoints.docket_alerts import (
+    DocketAlertsEndpoint,
+)
+
+if TYPE_CHECKING:
+    from courtlistener.async_client.client import AsyncCourtListener
+
+
+class AsyncSearchAlerts(AsyncResource):
+    """Helper for managing search alerts."""
+
+    def __init__(self, client: AsyncCourtListener) -> None:
+        super().__init__(client, AlertsEndpoint)
+
+    async def create(
+        self,
+        name: str,
+        query: str | dict[str, Any],
+        rate: RateType,
+        alert_type: SearchAlertType | None = None,
+    ) -> dict[str, Any]:
+        """Create a new search alert."""
+        validated = SearchAlertCreate(
+            name=name, query=query, rate=rate, alert_type=alert_type
+        )
+        body = validated.model_dump(exclude_none=True)
+        return cast(
+            dict[str, Any],
+            await self._client._request("POST", self._endpoint, json=body),
+        )
+
+    async def update(self, id: int, **data: Any) -> dict[str, Any]:
+        """Update an existing search alert."""
+        validated = SearchAlertUpdate(**data)
+        body = validated.model_dump(exclude_none=True)
+        return cast(
+            dict[str, Any],
+            await self._client._request(
+                "PATCH", f"{self._endpoint}{id}/", json=body
+            ),
+        )
+
+    async def delete(self, id: int) -> None:
+        """Delete a search alert."""
+        await self._client._request("DELETE", f"{self._endpoint}{id}/")
+
+
+class AsyncDocketAlerts(AsyncResource):
+    """Helper for managing docket alerts (subscriptions)."""
+
+    def __init__(self, client: AsyncCourtListener) -> None:
+        super().__init__(client, DocketAlertsEndpoint)
+
+    async def create(
+        self, docket: int, alert_type: DocketAlertType = 1
+    ) -> dict[str, Any]:
+        """Create a new docket alert."""
+        validated = DocketAlertCreate(docket=docket, alert_type=alert_type)
+        return cast(
+            dict[str, Any],
+            await self._client._request(
+                "POST", self._endpoint, json=validated.model_dump()
+            ),
+        )
+
+    async def update(self, id: int, **data: Any) -> dict[str, Any]:
+        """Update an existing docket alert."""
+        validated = DocketAlertUpdate(**data)
+        body = validated.model_dump(exclude_none=True)
+        return cast(
+            dict[str, Any],
+            await self._client._request(
+                "PATCH", f"{self._endpoint}{id}/", json=body
+            ),
+        )
+
+    async def delete(self, id: int) -> None:
+        """Delete a docket alert."""
+        await self._client._request("DELETE", f"{self._endpoint}{id}/")
+
+    async def subscribe(self, docket: int) -> dict[str, Any]:
+        """Subscribe to a docket (convenience for create with type=1)."""
+        async for alert in self.list(docket=docket):
+            return {**alert, "already_subscribed": True}
+
+        return await self.create(docket, alert_type=1)
+
+    async def unsubscribe(self, docket: int) -> None:
+        """Unsubscribe from a docket by docket ID."""
+        results = self.list(docket=docket)
+        async for alert in results:
+            await self.delete(alert["id"])
+            return
+        raise ValueError(f"No docket alert found for docket {docket}")

--- a/courtlistener/async_client/citation_lookup.py
+++ b/courtlistener/async_client/citation_lookup.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
-
-import anyio
 
 from courtlistener.exceptions import CourtListenerAPIError
 
@@ -79,7 +78,7 @@ class AsyncCitationLookup:
             wait = _wait_until_seconds(e.detail)
             if wait is None:
                 raise
-            await anyio.sleep(wait)
+            await asyncio.sleep(wait)
             result = await self._client._request(
                 "POST", self.ENDPOINT, data={"text": text}
             )

--- a/courtlistener/async_client/citation_lookup.py
+++ b/courtlistener/async_client/citation_lookup.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import anyio
+
+from courtlistener.exceptions import CourtListenerAPIError
+
+if TYPE_CHECKING:
+    from courtlistener.async_client.client import AsyncCourtListener
+
+MAX_TEXT_LENGTH = 64_000
+THROTTLE_STATUS = 429
+MAX_RETRY_WAIT_SECONDS = 90.0
+
+
+class AsyncCitationLookup:
+    """Helper for the citation lookup and verification API.
+
+    This endpoint extracts citations from text using eyecite and verifies
+    them against CourtListener's database.
+
+    See: https://www.courtlistener.com/help/api/rest/citation-lookup/
+    """
+
+    ENDPOINT = "/citation-lookup/"
+
+    def __init__(self, client: AsyncCourtListener) -> None:
+        self._client = client
+
+    async def lookup_text(
+        self,
+        text: str,
+        *,
+        retry_on_rate_limit: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Look up all citations in a block of text.
+
+        Sends text to CourtListener's citation-lookup endpoint, which
+        uses eyecite to extract citations and matches them against the
+        database.
+
+        Args:
+            text: Legal text containing citations (max 64,000 chars).
+            retry_on_rate_limit: If True, a whole-request 429 response
+                triggers a single retry after sleeping until the
+                ``wait_until`` timestamp in the error body (capped at
+                ``MAX_RETRY_WAIT_SECONDS``). If the second attempt also
+                429s, the error is raised.
+
+        Returns:
+            List of citation results. Each result contains:
+            - citation: The citation string found
+            - normalized_citations: Canonical forms of the citation
+            - start_index/end_index: Position in the input text
+            - status: 200 (found), 404 (not found), 400 (invalid),
+              300 (ambiguous), 429 (throttled)
+            - error_message: Details if lookup failed
+            - clusters: Matched CourtListener cluster objects
+
+        Raises:
+            ValueError: If text exceeds 64,000 characters.
+            CourtListenerAPIError: On API errors (including 429 when
+                retry is disabled or the retry also fails).
+        """
+        if len(text) > MAX_TEXT_LENGTH:
+            raise ValueError(
+                f"Text length {len(text)} exceeds the maximum of "
+                f"{MAX_TEXT_LENGTH} characters."
+            )
+        try:
+            result = await self._client._request(
+                "POST", self.ENDPOINT, data={"text": text}
+            )
+        except CourtListenerAPIError as e:
+            if not retry_on_rate_limit or e.status_code != THROTTLE_STATUS:
+                raise
+            wait = _wait_until_seconds(e.detail)
+            if wait is None:
+                raise
+            await anyio.sleep(wait)
+            result = await self._client._request(
+                "POST", self.ENDPOINT, data={"text": text}
+            )
+        assert isinstance(result, list)
+        return result
+
+    async def lookup_citation(
+        self, volume: int, reporter: str, page: str
+    ) -> list[dict[str, Any]]:
+        """Look up a specific citation by volume/reporter/page.
+
+        Args:
+            volume: Volume number (e.g., 576).
+            reporter: Reporter abbreviation (e.g., "U.S.", "F.3d").
+            page: Page number or string (e.g., "644").
+
+        Returns:
+            List of citation results with matched cluster objects.
+        """
+        result = await self._client._request(
+            "POST",
+            self.ENDPOINT,
+            data={
+                "volume": str(volume),
+                "reporter": reporter,
+                "page": page,
+            },
+        )
+        assert isinstance(result, list)
+        return result
+
+    async def lookup_text_batched(self, text: str) -> list[dict[str, Any]]:
+        """Look up citations with automatic handling for large texts.
+
+        Handles texts that exceed either the 64,000 character limit or
+        the 250 citation-per-request throttle. Texts longer than 64,000
+        characters are split at whitespace boundaries. When the API
+        throttles citations beyond the 250th (status 429), the
+        remaining text is re-submitted automatically.
+
+        Args:
+            text: Legal text of any length.
+
+        Returns:
+            Combined list of all citation results across batches.
+        """
+        all_results: list[dict[str, Any]] = []
+
+        for chunk_offset, chunk in _split_text(text):
+            chunk_results = await self._lookup_chunk(chunk, chunk_offset)
+            all_results.extend(chunk_results)
+
+        return all_results
+
+    async def _lookup_chunk(
+        self, chunk: str, base_offset: int
+    ) -> list[dict[str, Any]]:
+        """Look up citations in a single chunk, re-submitting on 429s.
+
+        Args:
+            chunk: Text chunk within the 64,000 char limit.
+            base_offset: Character offset of this chunk in the
+                original text, used to adjust start/end indices.
+
+        Returns:
+            Citation results with indices adjusted to the original text.
+        """
+        all_results: list[dict[str, Any]] = []
+        remaining = chunk
+        running_offset = 0
+
+        while remaining:
+            results = await self.lookup_text(remaining)
+            throttled: list[dict[str, Any]] = []
+            resolved: list[dict[str, Any]] = []
+
+            for r in results:
+                if r["status"] == THROTTLE_STATUS:
+                    throttled.append(r)
+                else:
+                    resolved.append(r)
+
+            # Adjust indices to account for chunk and sub-chunk offsets
+            total_offset = base_offset + running_offset
+            if total_offset > 0:
+                for r in resolved:
+                    r["start_index"] += total_offset
+                    r["end_index"] += total_offset
+
+            all_results.extend(resolved)
+
+            if not throttled:
+                break
+
+            # Re-submit from the start of the first throttled citation
+            first_throttled_start = throttled[0]["start_index"]
+            running_offset += first_throttled_start
+            remaining = remaining[first_throttled_start:]
+
+        return all_results
+
+
+def parse_wait_until(detail: Any) -> datetime | None:
+    """Parse the ``wait_until`` timestamp from a 429 error body.
+
+    Returns a timezone-aware datetime, or None if the body shape is
+    unexpected or the value can't be parsed. Naive timestamps are
+    interpreted as UTC.
+    """
+    if not isinstance(detail, dict):
+        return None
+    wait_until = detail.get("wait_until")
+    if not isinstance(wait_until, str):
+        return None
+    try:
+        target = datetime.fromisoformat(wait_until)
+    except ValueError:
+        return None
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=timezone.utc)
+    return target
+
+
+def _wait_until_seconds(detail: Any) -> float | None:
+    """Seconds to sleep before retrying a 429, clamped to the cap, or None."""
+    target = parse_wait_until(detail)
+    if target is None:
+        return None
+    seconds = (target - datetime.now(timezone.utc)).total_seconds()
+    return max(0.0, min(seconds, MAX_RETRY_WAIT_SECONDS))
+
+
+def _split_text(text: str) -> list[tuple[int, str]]:
+    """Split text into chunks of at most MAX_TEXT_LENGTH characters.
+
+    Splits at whitespace boundaries when possible.
+
+    Args:
+        text: The text to split.
+
+    Returns:
+        List of (offset, chunk) tuples.
+    """
+    if len(text) <= MAX_TEXT_LENGTH:
+        return [(0, text)]
+
+    chunks: list[tuple[int, str]] = []
+    offset = 0
+
+    while offset < len(text):
+        end = offset + MAX_TEXT_LENGTH
+
+        if end >= len(text):
+            chunks.append((offset, text[offset:]))
+            break
+
+        # Find last whitespace before the limit
+        split_at = text.rfind(" ", offset, end)
+        if split_at <= offset:
+            # No whitespace found; split at the hard limit
+            split_at = end
+
+        chunks.append((offset, text[offset:split_at]))
+        offset = split_at
+
+    return chunks

--- a/courtlistener/async_client/client.py
+++ b/courtlistener/async_client/client.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from courtlistener.async_client.resource import AsyncResource
+from courtlistener.exceptions import CourtListenerAPIError
+from courtlistener.models import ENDPOINTS
+
+if TYPE_CHECKING:
+    from courtlistener.async_client.alerts import (
+        AsyncDocketAlerts,
+        AsyncSearchAlerts,
+    )
+    from courtlistener.async_client.citation_lookup import AsyncCitationLookup
+
+DEFAULT_API_BASE_URL = "https://www.courtlistener.com/api/rest/v4"
+
+
+class AsyncCourtListener:
+    """Client for interacting with the CourtListener API."""
+
+    def __init__(
+        self,
+        api_token: str | None = None,
+        access_token: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 300.0,
+    ) -> None:
+        """Initialize the CourtListener client.
+
+        Args:
+            api_token: CourtListener API token, sent as
+                ``Authorization: Token <api_token>``. If not provided and
+                ``access_token`` is also not provided, will look for the
+                ``COURTLISTENER_API_TOKEN`` environment variable.
+            access_token: OAuth2 access token, sent as
+                ``Authorization: Bearer <access_token>``. When set, it
+                takes precedence over ``api_token`` and the env var.
+            base_url: Base URL for the CourtListener API.
+            timeout: Request timeout in seconds.
+        """
+        self.api_token = api_token or (
+            None if access_token else os.environ.get("COURTLISTENER_API_TOKEN")
+        )
+        self.access_token = access_token
+        if not self.api_token and not self.access_token:
+            raise ValueError(
+                "Authentication is required. Provide api_token, "
+                "access_token, or set COURTLISTENER_API_TOKEN "
+                "environment variable."
+            )
+
+        if base_url is None:
+            base_url = (
+                os.environ.get("COURTLISTENER_API_BASE_URL")
+                or DEFAULT_API_BASE_URL
+            )
+
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._http_client: httpx.AsyncClient | None = None
+        self._resources: dict[str, AsyncResource] = {}
+
+    @property
+    def alerts(self) -> AsyncSearchAlerts:
+        """Access the search alerts API."""
+        if not hasattr(self, "_alerts"):
+            from courtlistener.async_client.alerts import AsyncSearchAlerts
+
+            self._alerts = AsyncSearchAlerts(self)
+        return self._alerts
+
+    @property
+    def docket_alerts(self) -> AsyncDocketAlerts:
+        """Access the docket alerts API."""
+        if not hasattr(self, "_docket_alerts"):
+            from courtlistener.async_client.alerts import AsyncDocketAlerts
+
+            self._docket_alerts = AsyncDocketAlerts(self)
+        return self._docket_alerts
+
+    @property
+    def citation_lookup(self) -> AsyncCitationLookup:
+        """Access the citation lookup and verification API."""
+        if not hasattr(self, "_citation_lookup"):
+            from courtlistener.async_client.citation_lookup import (
+                AsyncCitationLookup,
+            )
+
+            self._citation_lookup = AsyncCitationLookup(self)
+        return self._citation_lookup
+
+    def __getattr__(self, name: str) -> AsyncResource:
+        """Dynamically create resource accessors based on registered endpoints."""
+        if not name.startswith("_"):
+            if name in self._resources:
+                return self._resources[name]
+
+            if name in ENDPOINTS:
+                resource: AsyncResource = AsyncResource(self, ENDPOINTS[name])
+                self._resources[name] = resource
+                return resource
+
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
+
+    @property
+    def client(self) -> httpx.AsyncClient:
+        """Get or create the HTTP client."""
+        if self._http_client is None:
+            if self.access_token:
+                auth_header = f"Bearer {self.access_token}"
+            else:
+                auth_header = f"Token {self.api_token}"
+            self._http_client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers={
+                    "Authorization": auth_header,
+                },
+                timeout=self.timeout,
+            )
+        return self._http_client
+
+    async def aclose(self) -> None:
+        """Close the HTTP client."""
+        if self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def __aenter__(self) -> AsyncCourtListener:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    async def _request(
+        self, method: str, path: str, **kwargs: Any
+    ) -> dict[str, Any] | list[Any]:
+        """Make an HTTP request to the API.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            path: API endpoint path
+            **kwargs: Additional arguments to pass to httpx
+
+        Returns:
+            Parsed JSON response (dict or list)
+        """
+
+        overlap = max(
+            i for i in range(len(path)) if self.base_url.endswith(path[:i])
+        )
+        if overlap:
+            path = path[overlap:]
+        response = await self.client.request(method, path, **kwargs)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError:
+            try:
+                detail = response.json()
+            except Exception:
+                detail = response.text
+            raise CourtListenerAPIError(
+                status_code=response.status_code,
+                detail=detail,
+                response=response,
+            ) from None
+        if response.status_code == 204:
+            return {}
+        return response.json()

--- a/courtlistener/async_client/resource.py
+++ b/courtlistener/async_client/resource.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
+
+from courtlistener.models import Endpoint, Page
+from courtlistener.utils import flatten_filters, validate_model_fields
+
+if TYPE_CHECKING:
+    from courtlistener.async_client.client import AsyncCourtListener
+
+
+class AsyncResourceIterator:
+    """Iterator for paginated API results."""
+
+    def __init__(
+        self,
+        resource: AsyncResource,
+        filters: dict[str, Any],
+    ) -> None:
+        self._client = resource._client
+        self._endpoint = resource._endpoint
+        self._filters = filters
+        self._current_page: Page | None = None
+        self._count: int | None = None
+        self._page_result_index: int = 0
+
+    async def _fetch_page(self, url: str | None = None) -> Page:
+        """Fetch a page of results."""
+        if url:
+            parsed = urlparse(url)
+            path = parsed.path
+            if parsed.query:
+                path = f"{path}?{parsed.query}"
+            data = cast(
+                dict[str, Any], await self._client._request("GET", path)
+            )
+        else:
+            data = cast(
+                dict[str, Any],
+                await self._client._request(
+                    "GET", self._endpoint, params=self._filters
+                ),
+            )
+        return Page(**data)
+
+    async def get_current_page(self) -> Page:
+        """Get the current page."""
+        if self._current_page is None:
+            self._current_page = await self._fetch_page()
+        return self._current_page
+
+    async def has_next(self) -> bool:
+        """Whether there is a next page."""
+        return (await self.get_current_page()).next is not None
+
+    async def has_previous(self) -> bool:
+        """Whether there is a previous page."""
+        return (await self.get_current_page()).previous is not None
+
+    async def next(self) -> None:
+        """Get the next page."""
+        if not await self.has_next():
+            raise ValueError("No next page")
+        current_page = await self.get_current_page()
+        self._current_page = await self._fetch_page(current_page.next)
+        self._page_result_index = 0
+
+    async def previous(self) -> None:
+        """Get the previous page."""
+        if not await self.has_previous():
+            raise ValueError("No previous page")
+        current_page = await self.get_current_page()
+        self._current_page = await self._fetch_page(current_page.previous)
+        self._page_result_index = 0
+
+    async def __aiter__(self) -> AsyncIterator[dict[str, Any]]:
+        """Iterate over all results across pages, respecting the page result index."""
+        while True:
+            current_page = await self.get_current_page()
+            for item in current_page.results[self._page_result_index :]:
+                self._page_result_index += 1
+                yield item
+            if not await self.has_next():
+                break
+            await self.next()
+
+    async def get_count(self) -> int:
+        """Total count of results across all pages."""
+        if self._count is None:
+            current_page = await self.get_current_page()
+            if current_page.count is None:
+                raise ValueError("No count URL")
+            elif isinstance(current_page.count, int):
+                self._count = current_page.count
+            else:
+                parsed = urlparse(current_page.count)
+                path = parsed.path
+                if parsed.query:
+                    path = f"{path}?{parsed.query}"
+                data = cast(
+                    dict[str, Any], await self._client._request("GET", path)
+                )
+                self._count = int(data.get("count", 0))
+        return self._count
+
+    async def get_document_count(self) -> int | None:
+        """Total count of nested documents for recap search endpoint."""
+        current_page = await self.get_current_page()
+        if current_page is not None:
+            return current_page.document_count
+        return None
+
+    async def get_results(self) -> list[dict[str, Any]]:
+        """Results from the current page."""
+        return (await self.get_current_page()).results
+
+    async def dump(self) -> dict[str, Any]:
+        """Serialize the iterator state to a dict for later restoration."""
+        current_page = await self.get_current_page()
+        return {
+            "current_page": current_page.model_dump(),
+            "filters": self._filters,
+            "endpoint": self._endpoint,
+            "page_result_index": self._page_result_index,
+            "count": self._count,
+        }
+
+    @classmethod
+    def load(
+        cls, client: AsyncCourtListener, data: dict[str, Any]
+    ) -> AsyncResourceIterator:
+        """Restore an AsyncResourceIterator from a previously dumped state."""
+        iterator = cls.__new__(cls)
+        iterator._client = client
+        iterator._endpoint = data["endpoint"]
+        iterator._filters = data["filters"]
+        iterator._current_page = Page(**data["current_page"])
+        iterator._page_result_index = data["page_result_index"]
+        iterator._count = data["count"]
+        return iterator
+
+
+class AsyncResource:
+    """Resource class for API endpoints."""
+
+    def __init__(
+        self,
+        client: AsyncCourtListener,
+        model: type[Endpoint],
+    ) -> None:
+        self._client = client
+        self._model = model
+        self._endpoint = model.endpoint
+
+    def validate_filters(self, filters: dict[str, Any]) -> dict[str, Any]:
+        filters = self._model(**filters).model_dump(by_alias=True)
+        filters = flatten_filters(filters)
+        filters = {k: v for k, v in filters.items() if v is not None}
+        return filters
+
+    async def get(
+        self, id: int | float | str, fields: list[str] | str | None = None
+    ) -> dict[str, Any]:
+        """Get a resource by its ID."""
+        if isinstance(id, float) and id.is_integer():
+            id = int(id)
+        params = {}
+        if fields:
+            fields = validate_model_fields(self._model, fields)
+            fields_str = ",".join(fields)
+            params["fields"] = fields_str
+        return cast(
+            dict[str, Any],
+            await self._client._request(
+                "GET", f"{self._endpoint}{id}/", params=params
+            ),
+        )
+
+    def list(self, **filters: Any) -> AsyncResourceIterator:
+        """List resources with optional filtering."""
+        valid_filters = self.validate_filters(filters)
+        return AsyncResourceIterator(self, valid_filters)

--- a/courtlistener/async_client/resource.py
+++ b/courtlistener/async_client/resource.py
@@ -107,10 +107,7 @@ class AsyncResourceIterator:
 
     async def get_document_count(self) -> int | None:
         """Total count of nested documents for recap search endpoint."""
-        current_page = await self.get_current_page()
-        if current_page is not None:
-            return current_page.document_count
-        return None
+        return (await self.get_current_page()).document_count
 
     async def get_results(self) -> list[dict[str, Any]]:
         """Results from the current page."""
@@ -131,7 +128,7 @@ class AsyncResourceIterator:
     def load(
         cls, client: AsyncCourtListener, data: dict[str, Any]
     ) -> AsyncResourceIterator:
-        """Restore an AsyncResourceIterator from a previously dumped state."""
+        """Restore the iterator from a previously dumped state."""
         iterator = cls.__new__(cls)
         iterator._client = client
         iterator._endpoint = data["endpoint"]

--- a/courtlistener/sync_client/resource.py
+++ b/courtlistener/sync_client/resource.py
@@ -104,10 +104,7 @@ class ResourceIterator:
 
     def get_document_count(self) -> int | None:
         """Total count of nested documents for recap search endpoint."""
-        current_page = self.get_current_page()
-        if current_page is not None:
-            return current_page.document_count
-        return None
+        return self.get_current_page().document_count
 
     def get_results(self) -> list[dict[str, Any]]:
         """Results from the current page."""
@@ -128,7 +125,7 @@ class ResourceIterator:
     def load(
         cls, client: CourtListener, data: dict[str, Any]
     ) -> ResourceIterator:
-        """Restore a ResourceIterator from a previously dumped state."""
+        """Restore the iterator from a previously dumped state."""
         iterator = cls.__new__(cls)
         iterator._client = client
         iterator._endpoint = data["endpoint"]
@@ -139,11 +136,8 @@ class ResourceIterator:
         return iterator
 
     # ------------------------------------------------------------------
-    # Deprecated property aliases.
-    #
-    # Kept only for backwards compatibility with pre-async-split code;
-    # they do not exist on AsyncResourceIterator and will not survive
-    # the planned unasync code generation. Use the get_* methods.
+    # Deprecated property aliases, kept for backwards compatibility.
+    # Use the get_* methods instead.
     # ------------------------------------------------------------------
 
     def _warn_deprecated(self, name: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "courtlistener-api-client"
-version = "1.1.0"
+version = "1.2.0"
 description = "Official Python SDK for the CourtListener API"
 authors = [{ name = "Free Law Project", email = "info@free.law" }]
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ urls.Repository = "https://github.com/freelawproject/courtlistener-api-client"
 urls."Organisation Homepage" = "https://free.law/"
 
 dependencies = [
-    "anyio>=4.0.0",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ include = ["courtlistener*"]
 [tool.setuptools.package-data]
 "courtlistener.mcp" = ["assets/*"]
 
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
+
 [tool.mypy]
 files = ["courtlistener"]
 python_version = "3.10"

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -162,6 +162,28 @@ class TestDocketAlertsSubscribeIdempotent:
         assert exc_info.value.status_code == 400
 
 
+class TestDocketAlertsUnsubscribe:
+    def test_deletes_existing_alert(self):
+        mock_client = MagicMock()
+        existing = {"id": 9, "docket": 5, "alert_type": 1}
+        mock_client._request.side_effect = [_page([existing]), {}]
+
+        da = DocketAlerts(mock_client)
+        da.unsubscribe(docket=5)
+
+        method, path = mock_client._request.call_args_list[1].args
+        assert method == "DELETE"
+        assert path.endswith("/9/")
+
+    def test_raises_when_no_alert(self):
+        mock_client = MagicMock()
+        mock_client._request.side_effect = [_page([])]
+
+        da = DocketAlerts(mock_client)
+        with pytest.raises(ValueError, match="No docket alert found"):
+            da.unsubscribe(docket=5)
+
+
 class TestDocketAlertsValidation:
     def test_docket_alert_invalid_alert_type_raises(self):
         mock_client = MagicMock()

--- a/tests/test_async_alerts.py
+++ b/tests/test_async_alerts.py
@@ -1,0 +1,139 @@
+"""Unit tests for AsyncSearchAlerts and AsyncDocketAlerts."""
+
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from courtlistener.async_client.alerts import (
+    AsyncDocketAlerts,
+    AsyncSearchAlerts,
+)
+from courtlistener.exceptions import CourtListenerAPIError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _mock_client(*responses):
+    client = MagicMock()
+    client._request = AsyncMock(side_effect=list(responses) or None)
+    return client
+
+
+def _page(results):
+    return {
+        "count": len(results),
+        "next": None,
+        "previous": None,
+        "results": results,
+    }
+
+
+class TestSearchAlerts:
+    async def test_create_posts_normalized_query(self):
+        client = _mock_client({"id": 1})
+        alerts = AsyncSearchAlerts(client)
+        await alerts.create(name="test", query={"q": "test"}, rate="dly")
+        body = client._request.await_args.kwargs["json"]
+        assert parse_qs(body["query"])["q"] == ["test"]
+        assert body["rate"] == "dly"
+
+    async def test_update_with_none_passes_through(self):
+        client = _mock_client({"id": 1})
+        alerts = AsyncSearchAlerts(client)
+        await alerts.update(1, name="new name")
+
+    async def test_update_with_dict_query(self):
+        client = _mock_client({"id": 1, "query": "q=test"})
+        alerts = AsyncSearchAlerts(client)
+        await alerts.update(1, query={"q": "test"})
+        body = client._request.await_args.kwargs["json"]
+        assert parse_qs(body["query"])["q"] == ["test"]
+
+    async def test_invalid_rate_raises(self):
+        alerts = AsyncSearchAlerts(_mock_client())
+        with pytest.raises(ValidationError):
+            await alerts.create(name="test", query="q=test", rate="invalid")
+
+    async def test_update_rejects_unknown_fields(self):
+        alerts = AsyncSearchAlerts(_mock_client())
+        with pytest.raises(ValidationError):
+            await alerts.update(1, unknown_field="value")
+
+    async def test_delete(self):
+        client = _mock_client({})
+        alerts = AsyncSearchAlerts(client)
+        await alerts.delete(3)
+        method, path = client._request.await_args.args
+        assert method == "DELETE"
+        assert path.endswith("/3/")
+
+
+class TestDocketAlertsSubscribeIdempotent:
+    async def test_creates_when_no_existing_subscription(self):
+        created = {"id": 1, "docket": 5, "alert_type": 1}
+        client = _mock_client(_page([]), created)
+
+        da = AsyncDocketAlerts(client)
+        result = await da.subscribe(docket=5)
+
+        assert result == created
+        assert "already_subscribed" not in result
+
+    async def test_returns_existing_with_flag(self):
+        existing = {"id": 1, "docket": 5, "alert_type": 1}
+        client = _mock_client(_page([existing]))
+
+        da = AsyncDocketAlerts(client)
+        result = await da.subscribe(docket=5)
+
+        assert result["id"] == 1
+        assert result["already_subscribed"] is True
+        # Pre-flight list only — no POST.
+        assert client._request.await_count == 1
+
+    async def test_create_400_still_raises(self):
+        other_error = CourtListenerAPIError(
+            400,
+            {"docket": ["Invalid pk."]},
+            MagicMock(spec=httpx.Response, status_code=400),
+        )
+        client = _mock_client(_page([]), other_error)
+
+        da = AsyncDocketAlerts(client)
+        with pytest.raises(CourtListenerAPIError) as exc_info:
+            await da.subscribe(docket=5)
+        assert exc_info.value.status_code == 400
+
+
+class TestDocketAlertsUnsubscribe:
+    async def test_deletes_existing_alert(self):
+        existing = {"id": 9, "docket": 5, "alert_type": 1}
+        client = _mock_client(_page([existing]), {})
+
+        da = AsyncDocketAlerts(client)
+        await da.unsubscribe(docket=5)
+
+        method, path = client._request.await_args_list[1].args
+        assert method == "DELETE"
+        assert path.endswith("/9/")
+
+    async def test_raises_when_no_alert(self):
+        client = _mock_client(_page([]))
+        da = AsyncDocketAlerts(client)
+        with pytest.raises(ValueError, match="No docket alert found"):
+            await da.unsubscribe(docket=5)
+
+
+class TestDocketAlertsValidation:
+    async def test_invalid_alert_type_raises(self):
+        da = AsyncDocketAlerts(_mock_client())
+        with pytest.raises(ValidationError):
+            await da.create(docket=1, alert_type=99)
+
+    async def test_update_rejects_unknown_fields(self):
+        da = AsyncDocketAlerts(_mock_client())
+        with pytest.raises(ValidationError):
+            await da.update(1, unknown_field="value")

--- a/tests/test_async_citation_lookup.py
+++ b/tests/test_async_citation_lookup.py
@@ -49,7 +49,7 @@ class TestLookupText:
         lookup = AsyncCitationLookup(client)
 
         with patch(
-            "courtlistener.async_client.citation_lookup.anyio.sleep",
+            "courtlistener.async_client.citation_lookup.asyncio.sleep",
             new_callable=AsyncMock,
         ) as mock_sleep:
             output = await lookup.lookup_text(
@@ -65,7 +65,7 @@ class TestLookupText:
         lookup = AsyncCitationLookup(client)
         with (
             patch(
-                "courtlistener.async_client.citation_lookup.anyio.sleep",
+                "courtlistener.async_client.citation_lookup.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             pytest.raises(CourtListenerAPIError),

--- a/tests/test_async_citation_lookup.py
+++ b/tests/test_async_citation_lookup.py
@@ -1,0 +1,148 @@
+"""Unit tests for the AsyncCitationLookup helper."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from courtlistener.async_client.citation_lookup import (
+    MAX_TEXT_LENGTH,
+    AsyncCitationLookup,
+)
+from courtlistener.exceptions import CourtListenerAPIError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _mock_client(*responses):
+    client = MagicMock()
+    client._request = AsyncMock(side_effect=list(responses) or None)
+    return client
+
+
+def _throttle_error(wait_seconds=1):
+    wait_until = datetime.now(timezone.utc) + timedelta(seconds=wait_seconds)
+    return CourtListenerAPIError(
+        429,
+        {"wait_until": wait_until.isoformat()},
+        MagicMock(spec=httpx.Response, status_code=429),
+    )
+
+
+class TestLookupText:
+    async def test_raises_on_oversized_text(self):
+        lookup = AsyncCitationLookup(_mock_client())
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            await lookup.lookup_text("x" * (MAX_TEXT_LENGTH + 1))
+
+    async def test_429_raises_without_retry_flag(self):
+        client = _mock_client(_throttle_error())
+        lookup = AsyncCitationLookup(client)
+        with pytest.raises(CourtListenerAPIError):
+            await lookup.lookup_text("576 U.S. 644")
+        assert client._request.await_count == 1
+
+    async def test_retry_on_rate_limit_sleeps_and_retries(self):
+        results = [{"citation": "576 U.S. 644", "status": 200}]
+        client = _mock_client(_throttle_error(), results)
+        lookup = AsyncCitationLookup(client)
+
+        with patch(
+            "courtlistener.async_client.citation_lookup.anyio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep:
+            output = await lookup.lookup_text(
+                "576 U.S. 644", retry_on_rate_limit=True
+            )
+
+        assert output == results
+        assert client._request.await_count == 2
+        mock_sleep.assert_awaited_once()
+
+    async def test_second_429_raises(self):
+        client = _mock_client(_throttle_error(), _throttle_error())
+        lookup = AsyncCitationLookup(client)
+        with (
+            patch(
+                "courtlistener.async_client.citation_lookup.anyio.sleep",
+                new_callable=AsyncMock,
+            ),
+            pytest.raises(CourtListenerAPIError),
+        ):
+            await lookup.lookup_text("576 U.S. 644", retry_on_rate_limit=True)
+
+
+class TestLookupCitation:
+    async def test_posts_citation_parts(self):
+        client = _mock_client([{"citation": "576 U.S. 644", "status": 200}])
+        lookup = AsyncCitationLookup(client)
+        await lookup.lookup_citation(576, "U.S.", "644")
+        kwargs = client._request.await_args.kwargs
+        assert kwargs["data"] == {
+            "volume": "576",
+            "reporter": "U.S.",
+            "page": "644",
+        }
+
+
+class TestLookupTextBatched:
+    async def test_no_throttle_single_call(self):
+        lookup = AsyncCitationLookup(_mock_client())
+        results = [
+            {
+                "citation": "576 U.S. 644",
+                "status": 200,
+                "start_index": 0,
+                "end_index": 12,
+            }
+        ]
+
+        with patch.object(
+            lookup, "lookup_text", AsyncMock(return_value=results)
+        ):
+            output = await lookup.lookup_text_batched("576 U.S. 644")
+
+        assert len(output) == 1
+        assert output[0]["status"] == 200
+
+    async def test_resubmits_on_throttle(self):
+        lookup = AsyncCitationLookup(_mock_client())
+        text = "First 388 U.S. 1 then 576 U.S. 644"
+
+        first_call_results = [
+            {
+                "citation": "388 U.S. 1",
+                "status": 200,
+                "start_index": 6,
+                "end_index": 16,
+            },
+            {
+                "citation": "576 U.S. 644",
+                "status": 429,
+                "start_index": 22,
+                "end_index": 34,
+            },
+        ]
+        second_call_results = [
+            {
+                "citation": "576 U.S. 644",
+                "status": 200,
+                "start_index": 0,
+                "end_index": 12,
+            },
+        ]
+
+        with patch.object(
+            lookup,
+            "lookup_text",
+            AsyncMock(side_effect=[first_call_results, second_call_results]),
+        ):
+            output = await lookup.lookup_text_batched(text)
+
+        assert len(output) == 2
+        assert output[0]["status"] == 200
+        assert output[0]["start_index"] == 6
+        assert output[1]["status"] == 200
+        # Second result's index should be adjusted to original text
+        assert output[1]["start_index"] == 22

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -42,6 +42,27 @@ PAIRS = [
     (CitationLookup, AsyncCitationLookup),
 ]
 
+# Sync-only backwards-compat shims. They document the alias rather than
+# the operation, so they sit out the docstring comparison; their
+# behavior is covered by tests/test_pagination.py.
+DEPRECATED_ALIASES = frozenset(RENAMES[ResourceIterator])
+
+# (class name, member) pairs whose docstrings deliberately differ.
+DOCSTRING_EXEMPT = {
+    # The async flavor intentionally keeps the one-line summary.
+    ("DocketAlerts", "unsubscribe"),
+}
+
+
+def _doc(cls, name):
+    """Docstring of a class member, or None if it isn't documentable."""
+    attr = inspect.getattr_static(cls, name)
+    if isinstance(attr, classmethod):
+        attr = attr.__func__
+    if not (inspect.isfunction(attr) or isinstance(attr, property)):
+        return None
+    return inspect.getdoc(attr)
+
 
 def _public_members(cls):
     return {name for name in vars(cls) if not name.startswith("_")}
@@ -139,6 +160,28 @@ class TestSyncAsyncParity:
             if not inspect.isfunction(sync_attr):
                 continue
             assert _param_facts(sync_attr) == _param_facts(async_attr), name
+
+    @pytest.mark.parametrize(
+        "sync_cls,async_cls", PAIRS, ids=lambda c: c.__name__
+    )
+    def test_docstrings_match(self, sync_cls, async_cls):
+        """Shared members carry the same docs in both flavors.
+
+        Guards the unasync plan: once the sync client is generated from
+        the async source, any prose that only exists on the sync side is
+        silently lost. Deliberate divergences go in DOCSTRING_EXEMPT.
+        """
+        assert inspect.getdoc(sync_cls) == inspect.getdoc(async_cls)
+        renames = RENAMES.get(sync_cls, {})
+        for name in _public_members(sync_cls):
+            if name in DEPRECATED_ALIASES:
+                continue
+            if (sync_cls.__name__, name) in DOCSTRING_EXEMPT:
+                continue
+            sync_doc = _doc(sync_cls, name)
+            if sync_doc is None:
+                continue
+            assert sync_doc == _doc(async_cls, renames.get(name, name)), name
 
     def test_duplicated_citation_helpers_are_identical(self):
         """The pure helpers are deliberately duplicated per flavor.

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,215 @@
+"""Tests for AsyncCourtListener and sync/async API parity."""
+
+import inspect
+
+import pytest
+
+from courtlistener import AsyncCourtListener, CourtListener
+from courtlistener.async_client.alerts import (
+    AsyncDocketAlerts,
+    AsyncSearchAlerts,
+)
+from courtlistener.async_client.citation_lookup import AsyncCitationLookup
+from courtlistener.async_client.resource import (
+    AsyncResource,
+    AsyncResourceIterator,
+)
+from courtlistener.sync_client.alerts import DocketAlerts, SearchAlerts
+from courtlistener.sync_client.citation_lookup import CitationLookup
+from courtlistener.sync_client.resource import Resource, ResourceIterator
+
+# Sync members that are intentionally renamed in the async API. Both
+# clients expose ``get_*`` methods for the lazy accessors; the sync
+# property forms are deprecated backwards-compat aliases that collapse
+# onto the same methods here. close/context management follows the
+# httpx ``aclose``/``__aenter__`` convention.
+RENAMES = {
+    CourtListener: {"close": "aclose"},
+    ResourceIterator: {
+        "current_page": "get_current_page",
+        "count": "get_count",
+        "document_count": "get_document_count",
+        "results": "get_results",
+    },
+}
+
+PAIRS = [
+    (CourtListener, AsyncCourtListener),
+    (Resource, AsyncResource),
+    (ResourceIterator, AsyncResourceIterator),
+    (SearchAlerts, AsyncSearchAlerts),
+    (DocketAlerts, AsyncDocketAlerts),
+    (CitationLookup, AsyncCitationLookup),
+]
+
+
+def _public_members(cls):
+    return {name for name in vars(cls) if not name.startswith("_")}
+
+
+def _param_facts(func):
+    """Parameter (name, kind, default) triples for a function."""
+    return [
+        (param.name, param.kind, param.default)
+        for param in inspect.signature(func).parameters.values()
+    ]
+
+
+SELF_ONLY = [
+    ("self", inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.empty)
+]
+
+
+class TestSyncAsyncParity:
+    """Guardrails for keeping the two clients aligned (see unasync plan)."""
+
+    @pytest.mark.parametrize(
+        "sync_cls,async_cls", PAIRS, ids=lambda c: c.__name__
+    )
+    def test_public_api_surface_matches(self, sync_cls, async_cls):
+        renames = RENAMES.get(sync_cls, {})
+        expected = {
+            renames.get(name, name) for name in _public_members(sync_cls)
+        }
+        assert _public_members(async_cls) == expected
+
+    def test_context_manager_protocols(self):
+        assert hasattr(CourtListener, "__enter__")
+        assert hasattr(CourtListener, "__exit__")
+        assert hasattr(AsyncCourtListener, "__aenter__")
+        assert hasattr(AsyncCourtListener, "__aexit__")
+        assert not hasattr(AsyncCourtListener, "__enter__")
+
+    def test_iterator_protocols(self):
+        assert hasattr(ResourceIterator, "__iter__")
+        assert hasattr(AsyncResourceIterator, "__aiter__")
+        assert not hasattr(AsyncResourceIterator, "__iter__")
+
+    def test_io_methods_are_coroutines(self):
+        for method in (
+            AsyncCourtListener._request,
+            AsyncCourtListener.aclose,
+            AsyncResource.get,
+            AsyncResourceIterator.get_current_page,
+            AsyncResourceIterator.get_count,
+            AsyncResourceIterator.get_results,
+            AsyncResourceIterator.get_document_count,
+            AsyncResourceIterator.dump,
+            AsyncResourceIterator.next,
+            AsyncResourceIterator.previous,
+            AsyncResourceIterator.has_next,
+            AsyncResourceIterator.has_previous,
+            AsyncSearchAlerts.create,
+            AsyncDocketAlerts.subscribe,
+            AsyncCitationLookup.lookup_text,
+        ):
+            assert inspect.iscoroutinefunction(method), method
+
+    def test_list_is_not_a_coroutine(self):
+        """list() performs no I/O in either client."""
+        assert not inspect.iscoroutinefunction(AsyncResource.list)
+
+    @pytest.mark.parametrize(
+        "sync_cls,async_cls", PAIRS, ids=lambda c: c.__name__
+    )
+    def test_signatures_match(self, sync_cls, async_cls):
+        """Shared public methods take identical arguments.
+
+        Compares parameter name, kind, and default (not annotations,
+        which legitimately differ between flavors). Sync properties
+        renamed to awaitable ``get_*`` methods must take no arguments;
+        non-renamed sync properties must stay properties in async.
+        """
+        renames = RENAMES.get(sync_cls, {})
+        for name in _public_members(sync_cls):
+            sync_attr = inspect.getattr_static(sync_cls, name)
+            async_attr = inspect.getattr_static(
+                async_cls, renames.get(name, name)
+            )
+            if isinstance(sync_attr, property):
+                if name in renames:
+                    assert inspect.iscoroutinefunction(async_attr), name
+                    assert _param_facts(async_attr) == SELF_ONLY, name
+                else:
+                    assert isinstance(async_attr, property), name
+                continue
+            if isinstance(sync_attr, classmethod):
+                sync_attr = sync_attr.__func__
+                async_attr = async_attr.__func__
+            if not inspect.isfunction(sync_attr):
+                continue
+            assert _param_facts(sync_attr) == _param_facts(async_attr), name
+
+    def test_duplicated_citation_helpers_are_identical(self):
+        """The pure helpers are deliberately duplicated per flavor.
+
+        Until the sync side is generated with unasync, keep the copies
+        byte-identical so they can't drift.
+        """
+        import courtlistener.async_client.citation_lookup as async_mod
+        import courtlistener.sync_client.citation_lookup as sync_mod
+
+        for name in ("parse_wait_until", "_wait_until_seconds", "_split_text"):
+            assert inspect.getsource(
+                getattr(sync_mod, name)
+            ) == inspect.getsource(getattr(async_mod, name)), name
+        for name in (
+            "MAX_TEXT_LENGTH",
+            "THROTTLE_STATUS",
+            "MAX_RETRY_WAIT_SECONDS",
+        ):
+            assert getattr(sync_mod, name) == getattr(async_mod, name), name
+
+
+class TestAsyncClientConstruction:
+    def test_requires_authentication(self, monkeypatch):
+        monkeypatch.delenv("COURTLISTENER_API_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="Authentication is required"):
+            AsyncCourtListener()
+
+    def test_env_var_token(self, monkeypatch):
+        monkeypatch.setenv("COURTLISTENER_API_TOKEN", "env-token")
+        cl = AsyncCourtListener()
+        assert cl.api_token == "env-token"
+
+    def test_access_token_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("COURTLISTENER_API_TOKEN", "env-token")
+        cl = AsyncCourtListener(access_token="oauth")
+        assert cl.access_token == "oauth"
+        assert cl.api_token is None
+        assert cl.client.headers["Authorization"] == "Bearer oauth"
+
+    def test_api_token_header(self):
+        cl = AsyncCourtListener(api_token="tok")
+        assert cl.client.headers["Authorization"] == "Token tok"
+
+    def test_resource_accessors_are_cached(self):
+        cl = AsyncCourtListener(api_token="tok")
+        resource = cl.courts
+        assert isinstance(resource, AsyncResource)
+        assert cl.courts is resource
+
+    def test_unknown_attribute_raises(self):
+        cl = AsyncCourtListener(api_token="tok")
+        with pytest.raises(AttributeError):
+            _ = cl.not_an_endpoint
+
+    def test_addon_accessors(self):
+        cl = AsyncCourtListener(api_token="tok")
+        assert isinstance(cl.alerts, AsyncSearchAlerts)
+        assert isinstance(cl.docket_alerts, AsyncDocketAlerts)
+        assert isinstance(cl.citation_lookup, AsyncCitationLookup)
+
+    @pytest.mark.asyncio
+    async def test_context_manager_closes_client(self):
+        async with AsyncCourtListener(api_token="tok") as cl:
+            http_client = cl.client
+            assert not http_client.is_closed
+        assert cl._http_client is None
+        assert http_client.is_closed
+
+    @pytest.mark.asyncio
+    async def test_aclose_without_client_is_noop(self):
+        cl = AsyncCourtListener(api_token="tok")
+        await cl.aclose()
+        assert cl._http_client is None

--- a/tests/test_async_exceptions.py
+++ b/tests/test_async_exceptions.py
@@ -1,19 +1,21 @@
-"""Tests for CourtListenerAPIError and error handling in _request."""
+"""Async mirror of test_exceptions.py: error handling in _request."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from courtlistener import CourtListener
+from courtlistener import AsyncCourtListener
 from courtlistener.exceptions import CourtListenerAPIError
+
+pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
 def cl():
-    """Create a CourtListener client with a mocked HTTP client."""
+    """Create an AsyncCourtListener client with a mocked HTTP client."""
     with patch.dict("os.environ", {"COURTLISTENER_API_TOKEN": "test-token"}):
-        client = CourtListener(api_token="test-token")
+        client = AsyncCourtListener(api_token="test-token")
     return client
 
 
@@ -45,77 +47,69 @@ def _make_response(status_code, json_body=None, text=""):
 def _attach(cl, response):
     """Wire a response onto the client's HTTP layer, return the mock."""
     cl._http_client = MagicMock()
-    cl._http_client.request = MagicMock(return_value=response)
+    cl._http_client.request = AsyncMock(return_value=response)
     return cl._http_client.request
 
 
 class TestCourtListenerAPIError:
-    def test_json_detail_dict(self, cl):
+    async def test_json_detail_dict(self, cl):
         body = {"detail": "Authentication credentials were not provided."}
-        response = _make_response(403, json_body=body)
-        cl._http_client = MagicMock()
-        cl._http_client.request.return_value = response
+        _attach(cl, _make_response(403, json_body=body))
 
         with pytest.raises(CourtListenerAPIError) as exc_info:
-            cl._request("GET", "/dockets/")
+            await cl._request("GET", "/dockets/")
 
         err = exc_info.value
         assert err.status_code == 403
         assert err.detail == body
         assert "Authentication credentials were not provided." in str(err)
 
-    def test_json_detail_field_errors(self, cl):
+    async def test_json_detail_field_errors(self, cl):
         body = {"name": ["This field is required."]}
-        response = _make_response(400, json_body=body)
-        cl._http_client = MagicMock()
-        cl._http_client.request.return_value = response
+        _attach(cl, _make_response(400, json_body=body))
 
         with pytest.raises(CourtListenerAPIError) as exc_info:
-            cl._request("POST", "/alerts/")
+            await cl._request("POST", "/alerts/")
 
         err = exc_info.value
         assert err.status_code == 400
         assert err.detail == body
         assert "HTTP 400" in str(err)
 
-    def test_non_json_response(self, cl):
+    async def test_non_json_response(self, cl):
         html = "<html><body>502 Bad Gateway</body></html>"
-        response = _make_response(502, text=html)
-        cl._http_client = MagicMock()
-        cl._http_client.request.return_value = response
+        _attach(cl, _make_response(502, text=html))
 
         with pytest.raises(CourtListenerAPIError) as exc_info:
-            cl._request("GET", "/dockets/")
+            await cl._request("GET", "/dockets/")
 
         err = exc_info.value
         assert err.status_code == 502
         assert err.detail == html
         assert "502 Bad Gateway" in str(err)
 
-    def test_response_attribute(self, cl):
+    async def test_response_attribute(self, cl):
         response = _make_response(404, json_body={"detail": "Not found."})
-        cl._http_client = MagicMock()
-        cl._http_client.request.return_value = response
+        _attach(cl, response)
 
         with pytest.raises(CourtListenerAPIError) as exc_info:
-            cl._request("GET", "/dockets/999999/")
+            await cl._request("GET", "/dockets/999999/")
 
         assert exc_info.value.response is response
 
-    def test_successful_request_no_error(self, cl):
+    async def test_successful_request_no_error(self, cl):
         response = MagicMock(spec=httpx.Response)
         response.status_code = 200
         response.raise_for_status = MagicMock()
         response.json.return_value = {"id": 1}
-        cl._http_client = MagicMock()
-        cl._http_client.request.return_value = response
+        _attach(cl, response)
 
-        result = cl._request("GET", "/dockets/1/")
+        result = await cl._request("GET", "/dockets/1/")
         assert result == {"id": 1}
 
 
 class TestRequestResponseHandling:
-    def test_204_returns_empty_dict(self, cl):
+    async def test_204_returns_empty_dict(self, cl):
         """DELETE returns no body; _request must not call .json()."""
         response = MagicMock(spec=httpx.Response)
         response.status_code = 204
@@ -123,9 +117,9 @@ class TestRequestResponseHandling:
         response.json.side_effect = ValueError("No JSON")
         _attach(cl, response)
 
-        assert cl._request("DELETE", "/alerts/1/") == {}
+        assert await cl._request("DELETE", "/alerts/1/") == {}
 
-    def test_absolute_path_is_trimmed_against_base_url(self, cl):
+    async def test_absolute_path_is_trimmed_against_base_url(self, cl):
         """Paginated URLs repeat the base path; the overlap is stripped."""
         response = MagicMock(spec=httpx.Response)
         response.status_code = 200
@@ -133,19 +127,19 @@ class TestRequestResponseHandling:
         response.json.return_value = {"results": []}
         request = _attach(cl, response)
 
-        cl._request("GET", "/api/rest/v4/dockets/?cursor=abc")
+        await cl._request("GET", "/api/rest/v4/dockets/?cursor=abc")
 
-        request.assert_called_once_with("GET", "/dockets/?cursor=abc")
+        request.assert_awaited_once_with("GET", "/dockets/?cursor=abc")
 
-    def test_relative_path_is_left_alone(self, cl):
+    async def test_relative_path_is_left_alone(self, cl):
         response = MagicMock(spec=httpx.Response)
         response.status_code = 200
         response.raise_for_status = MagicMock()
         response.json.return_value = {"results": []}
         request = _attach(cl, response)
 
-        cl._request("GET", "/dockets/", params={"court": "scotus"})
+        await cl._request("GET", "/dockets/", params={"court": "scotus"})
 
-        request.assert_called_once_with(
+        request.assert_awaited_once_with(
             "GET", "/dockets/", params={"court": "scotus"}
         )

--- a/tests/test_async_pagination.py
+++ b/tests/test_async_pagination.py
@@ -1,0 +1,156 @@
+"""Unit tests for AsyncResourceIterator pagination behavior."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from courtlistener import AsyncCourtListener
+from courtlistener.async_client.resource import AsyncResourceIterator
+
+pytestmark = pytest.mark.asyncio
+
+NEXT_URL = "https://www.courtlistener.com/api/rest/v4/courts/?cursor=abc"
+
+
+def _page(results, next=None, previous=None, count=None):
+    return {
+        "count": count if count is not None else len(results),
+        "next": next,
+        "previous": previous,
+        "results": results,
+    }
+
+
+def _iterator(pages) -> AsyncResourceIterator:
+    cl = AsyncCourtListener(api_token="tok")
+    cl._request = AsyncMock(side_effect=pages)
+    return cl.courts.list()
+
+
+class TestCurrentPage:
+    async def test_fetches_first_page(self):
+        it = _iterator([_page([{"id": "scotus"}])])
+        page = await it.get_current_page()
+        assert page.results == [{"id": "scotus"}]
+
+    async def test_page_is_cached(self):
+        it = _iterator([_page([{"id": "scotus"}])])
+        first = await it.get_current_page()
+        second = await it.get_current_page()
+        assert first is second
+        assert it._client._request.await_count == 1
+
+    async def test_results_shortcut(self):
+        it = _iterator([_page([{"id": "scotus"}])])
+        assert await it.get_results() == [{"id": "scotus"}]
+
+
+class TestNavigation:
+    async def test_has_next(self):
+        it = _iterator([_page([{"id": 1}], next=NEXT_URL)])
+        assert await it.has_next()
+
+    async def test_no_next(self):
+        it = _iterator([_page([{"id": 1}])])
+        assert not await it.has_next()
+
+    async def test_next_fetches_next_url(self):
+        it = _iterator(
+            [
+                _page([{"id": 1}], next=NEXT_URL),
+                _page([{"id": 2}], previous="prev"),
+            ]
+        )
+        await it.next()
+        assert await it.get_results() == [{"id": 2}]
+        method, path = it._client._request.await_args_list[1].args
+        assert method == "GET"
+        assert path == "/api/rest/v4/courts/?cursor=abc"
+
+    async def test_next_raises_without_next_page(self):
+        it = _iterator([_page([{"id": 1}])])
+        with pytest.raises(ValueError, match="No next page"):
+            await it.next()
+
+    async def test_previous_raises_on_first_page(self):
+        it = _iterator([_page([{"id": 1}])])
+        assert not await it.has_previous()
+        with pytest.raises(ValueError, match="No previous page"):
+            await it.previous()
+
+
+class TestIteration:
+    async def test_iterates_across_pages(self):
+        it = _iterator(
+            [
+                _page([{"id": 1}, {"id": 2}], next=NEXT_URL),
+                _page([{"id": 3}]),
+            ]
+        )
+        items = [item async for item in it]
+        assert [item["id"] for item in items] == [1, 2, 3]
+
+    async def test_iteration_respects_result_index(self):
+        it = _iterator([_page([{"id": 1}, {"id": 2}, {"id": 3}])])
+        collected = []
+        async for item in it:
+            collected.append(item)
+            if len(collected) == 2:
+                break
+        assert [item["id"] async for item in it] == [3]
+
+
+class TestCount:
+    async def test_integer_count(self):
+        it = _iterator([_page([{"id": 1}], count=42)])
+        assert await it.get_count() == 42
+
+    async def test_count_url_is_fetched(self):
+        count_url = (
+            "https://www.courtlistener.com/api/rest/v4/courts/?count=on"
+        )
+        it = _iterator(
+            [
+                _page([{"id": 1}], count=count_url),
+                {"count": 99},
+            ]
+        )
+        assert await it.get_count() == 99
+        method, path = it._client._request.await_args_list[1].args
+        assert path == "/api/rest/v4/courts/?count=on"
+
+    async def test_count_is_cached(self):
+        it = _iterator([_page([{"id": 1}], count=42)])
+        await it.get_count()
+        await it.get_count()
+        assert it._client._request.await_count == 1
+
+    async def test_missing_count_raises(self):
+        it = _iterator([_page([{"id": 1}], count=-1) | {"count": None}])
+        with pytest.raises(ValueError, match="No count URL"):
+            await it.get_count()
+
+
+class TestDumpLoad:
+    async def test_round_trip_uses_cached_page(self):
+        it = _iterator([_page([{"id": 1}], count=7)])
+        await it.get_count()
+        state = await it.dump()
+
+        restored_client = AsyncCourtListener(api_token="tok")
+        restored_client._request = AsyncMock()
+        restored = AsyncResourceIterator.load(restored_client, state)
+
+        assert await restored.get_results() == [{"id": 1}]
+        assert await restored.get_count() == 7
+        restored_client._request.assert_not_awaited()
+
+    async def test_dump_preserves_position(self):
+        it = _iterator([_page([{"id": 1}, {"id": 2}])])
+        collected = []
+        async for item in it:
+            collected.append(item)
+            if len(collected) == 1:
+                break
+        state = await it.dump()
+        assert state["page_result_index"] == 1

--- a/tests/test_async_resource_get.py
+++ b/tests/test_async_resource_get.py
@@ -1,0 +1,36 @@
+"""Unit tests for `AsyncResource.get` id handling.
+
+JSON clients often send integral floats (5.0) for integer ids; the
+filter path already coerces these via the pydantic endpoint models, so
+`get` matches that tolerance when building the URL.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from courtlistener.async_client.resource import AsyncResource
+from courtlistener.models import ENDPOINTS
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestGetIdNormalization:
+    async def _requested_path(self, id):
+        client = MagicMock()
+        client._request = AsyncMock(return_value={})
+        await AsyncResource(client, ENDPOINTS["dockets"]).get(id)
+        return client._request.await_args.args[1]
+
+    async def test_integral_float_is_normalized(self):
+        assert (await self._requested_path(5.0)).endswith("/5/")
+
+    async def test_int_passes_through(self):
+        assert (await self._requested_path(5)).endswith("/5/")
+
+    async def test_str_passes_through(self):
+        assert (await self._requested_path("scotus")).endswith("/scotus/")
+
+    async def test_non_integral_float_is_left_alone(self):
+        # Garbage in, garbage out: the API's 404 is the error surface.
+        assert (await self._requested_path(5.5)).endswith("/5.5/")

--- a/tests/test_citation_lookup.py
+++ b/tests/test_citation_lookup.py
@@ -1,13 +1,73 @@
 """Tests for the CitationLookup helper."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
+from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.sync_client.citation_lookup import (
+    MAX_TEXT_LENGTH,
     CitationLookup,
     _split_text,
 )
+
+
+def _mock_client(*responses):
+    client = MagicMock()
+    client._request = MagicMock(side_effect=list(responses) or None)
+    return client
+
+
+def _throttle_error(wait_seconds=1):
+    wait_until = datetime.now(timezone.utc) + timedelta(seconds=wait_seconds)
+    return CourtListenerAPIError(
+        429,
+        {"wait_until": wait_until.isoformat()},
+        MagicMock(spec=httpx.Response, status_code=429),
+    )
+
+
+class TestRateLimitRetry:
+    """Mirrors TestLookupText in tests/test_async_citation_lookup.py."""
+
+    def test_raises_on_oversized_text(self):
+        lookup = CitationLookup(_mock_client())
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            lookup.lookup_text("x" * (MAX_TEXT_LENGTH + 1))
+
+    def test_429_raises_without_retry_flag(self):
+        client = _mock_client(_throttle_error())
+        lookup = CitationLookup(client)
+        with pytest.raises(CourtListenerAPIError):
+            lookup.lookup_text("576 U.S. 644")
+        assert client._request.call_count == 1
+
+    def test_retry_on_rate_limit_sleeps_and_retries(self):
+        results = [{"citation": "576 U.S. 644", "status": 200}]
+        client = _mock_client(_throttle_error(), results)
+        lookup = CitationLookup(client)
+
+        with patch(
+            "courtlistener.sync_client.citation_lookup.time.sleep"
+        ) as mock_sleep:
+            output = lookup.lookup_text(
+                "576 U.S. 644", retry_on_rate_limit=True
+            )
+
+        assert output == results
+        assert client._request.call_count == 2
+        mock_sleep.assert_called_once()
+
+    def test_second_429_raises(self):
+        client = _mock_client(_throttle_error(), _throttle_error())
+        lookup = CitationLookup(client)
+        with (
+            patch("courtlistener.sync_client.citation_lookup.time.sleep"),
+            pytest.raises(CourtListenerAPIError),
+        ):
+            lookup.lookup_text("576 U.S. 644", retry_on_rate_limit=True)
 
 
 @pytest.mark.integration

--- a/tests/test_mcp_document_ids.py
+++ b/tests/test_mcp_document_ids.py
@@ -34,13 +34,13 @@ class FakeIterator:
 
     def __init__(self, results):
         self._results = list(results)
-        self.current_page = SimpleNamespace(
+        self._current_page = SimpleNamespace(
             results=self._results, count=len(self._results)
         )
         self._page_result_index = len(self._results)
 
     def get_current_page(self):
-        return self.current_page
+        return self._current_page
 
     def __iter__(self):
         return iter(self._results)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,4 +1,8 @@
-"""Tests for pagination behavior: integration plus deprecation shims."""
+"""Tests for pagination behavior: unit, integration, deprecation shims.
+
+The unit classes mirror tests/test_async_pagination.py one-for-one; keep
+the two in step so a generated sync client stays covered.
+"""
 
 import warnings
 from contextlib import contextmanager
@@ -7,6 +11,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from courtlistener import CourtListener
+from courtlistener.sync_client.resource import ResourceIterator
+
+NEXT_URL = "https://www.courtlistener.com/api/rest/v4/courts/?cursor=abc"
 
 
 @contextmanager
@@ -14,6 +21,21 @@ def warnings_as_errors():
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         yield
+
+
+def _page(results, next=None, previous=None, count=None):
+    return {
+        "count": count if count is not None else len(results),
+        "next": next,
+        "previous": previous,
+        "results": results,
+    }
+
+
+def _iterator(pages) -> ResourceIterator:
+    cl = CourtListener(api_token="tok")
+    cl._request = MagicMock(side_effect=pages)
+    return cl.courts.list()
 
 
 @pytest.mark.integration
@@ -66,19 +88,133 @@ class TestPagination:
             results.previous()
 
 
-def _iterator(pages):
-    cl = CourtListener(api_token="tok")
-    cl._request = MagicMock(side_effect=pages)
-    return cl.courts.list()
+class TestCurrentPage:
+    def test_fetches_first_page(self):
+        it = _iterator([_page([{"id": "scotus"}])])
+        page = it.get_current_page()
+        assert page.results == [{"id": "scotus"}]
+
+    def test_page_is_cached(self):
+        it = _iterator([_page([{"id": "scotus"}])])
+        first = it.get_current_page()
+        second = it.get_current_page()
+        assert first is second
+        assert it._client._request.call_count == 1
+
+    def test_results_shortcut(self):
+        it = _iterator([_page([{"id": "scotus"}])])
+        assert it.get_results() == [{"id": "scotus"}]
 
 
-def _page(results, count=None):
-    return {
-        "count": count if count is not None else len(results),
-        "next": None,
-        "previous": None,
-        "results": results,
-    }
+class TestNavigation:
+    def test_has_next(self):
+        it = _iterator([_page([{"id": 1}], next=NEXT_URL)])
+        assert it.has_next()
+
+    def test_no_next(self):
+        it = _iterator([_page([{"id": 1}])])
+        assert not it.has_next()
+
+    def test_next_fetches_next_url(self):
+        it = _iterator(
+            [
+                _page([{"id": 1}], next=NEXT_URL),
+                _page([{"id": 2}], previous="prev"),
+            ]
+        )
+        it.next()
+        assert it.get_results() == [{"id": 2}]
+        method, path = it._client._request.call_args_list[1].args
+        assert method == "GET"
+        assert path == "/api/rest/v4/courts/?cursor=abc"
+
+    def test_next_raises_without_next_page(self):
+        it = _iterator([_page([{"id": 1}])])
+        with pytest.raises(ValueError, match="No next page"):
+            it.next()
+
+    def test_previous_raises_on_first_page(self):
+        it = _iterator([_page([{"id": 1}])])
+        assert not it.has_previous()
+        with pytest.raises(ValueError, match="No previous page"):
+            it.previous()
+
+
+class TestIteration:
+    def test_iterates_across_pages(self):
+        it = _iterator(
+            [
+                _page([{"id": 1}, {"id": 2}], next=NEXT_URL),
+                _page([{"id": 3}]),
+            ]
+        )
+        items = list(it)
+        assert [item["id"] for item in items] == [1, 2, 3]
+
+    def test_iteration_respects_result_index(self):
+        it = _iterator([_page([{"id": 1}, {"id": 2}, {"id": 3}])])
+        collected = []
+        for item in it:
+            collected.append(item)
+            if len(collected) == 2:
+                break
+        assert [item["id"] for item in it] == [3]
+
+
+class TestCount:
+    def test_integer_count(self):
+        it = _iterator([_page([{"id": 1}], count=42)])
+        assert it.get_count() == 42
+
+    def test_count_url_is_fetched(self):
+        count_url = (
+            "https://www.courtlistener.com/api/rest/v4/courts/?count=on"
+        )
+        it = _iterator(
+            [
+                _page([{"id": 1}], count=count_url),
+                {"count": 99},
+            ]
+        )
+        assert it.get_count() == 99
+        method, path = it._client._request.call_args_list[1].args
+        assert path == "/api/rest/v4/courts/?count=on"
+
+    def test_count_is_cached(self):
+        it = _iterator([_page([{"id": 1}], count=42)])
+        it.get_count()
+        it.get_count()
+        assert it._client._request.call_count == 1
+
+    def test_missing_count_raises(self):
+        it = _iterator([_page([{"id": 1}], count=-1) | {"count": None}])
+        with pytest.raises(ValueError, match="No count URL"):
+            it.get_count()
+
+
+class TestDumpLoad:
+    def test_round_trip_uses_cached_page(self):
+        it = _iterator([_page([{"id": 1}], count=7)])
+        it.get_count()
+        state = it.dump()
+
+        restored_client = CourtListener(api_token="tok")
+        restored_client._request = MagicMock()
+        restored = ResourceIterator.load(restored_client, state)
+
+        assert restored.get_results() == [{"id": 1}]
+        assert restored.get_count() == 7
+        restored_client._request.assert_not_called()
+
+    def test_dump_preserves_position(self):
+        it = _iterator([_page([{"id": 1}, {"id": 2}])])
+        collected = []
+        for item in it:
+            collected.append(item)
+            if len(collected) == 1:
+                break
+        state = it.dump()
+        assert state["page_result_index"] == 1
 
 
 class TestDeprecatedProperties:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{313}
+envlist = py{310,311,312,313}
 
 [testenv]
 runner = uv-venv-lock-runner

--- a/uv.lock
+++ b/uv.lock
@@ -354,10 +354,9 @@ wheels = [
 
 [[package]]
 name = "courtlistener-api-client"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "anyio" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
@@ -388,7 +387,6 @@ mcp = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=4.0.0" },
     { name = "click", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "eyecite", marker = "extra == 'mcp'", specifier = ">=2.6.0" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = "==3.4.0" },


### PR DESCRIPTION
Fixes #222

This PR adds `AsyncCourtListener` -- the async client for the CL API.

The goal here is to mirror the sync client exactly. In a later PR we will use `unasync` to generate the sync client.
For all of the duplicative classes, the sync client ones have been moved to their own module.

The top level package now exports everything from both clients -- `CourtListener` and `AsyncCourtListener`, their `Resource`/`ResourceIterator`, the alerts and citation lookup helpers, and both exception types. Every name that was importable from `courtlistener` before the split still is, now alongside its async counterpart.

The sync client should remain fundamentally unchanged. The only modification is that we have replaced lazy property decorated atts that make http calls with methods (so there can be awaitable analogues in the async client). We leave the replaced attributes for backwards compatibility, but they warn and are considered deprecated and shouldn't be used anywhere in our own code.

Also in here:
- Bumps the version to 1.2.0.
- Tests against Python 3.10 through 3.13 in CI, rather than 3.13 only, to match `requires-python`.
- Drops the `anyio` dependency in favor of `asyncio.sleep` for the citation lookup retry backoff.
- Brings the sync tests up to parity with the new async ones -- `_request` error handling, pagination, docket alert unsubscribe, and rate limit retry now have unit coverage on both sides.