### PR TITLE
feat(settings): move CL API base url to settings module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 The following changes are not yet released, but are code complete:
 
+Changes:
+- Add `courtlistener/settings.py` with `get_api_base_url()`, now the single source of truth for the CourtListener API root.
+
 ### 1.2.0 - 2026-08-04
 
 Features:

--- a/courtlistener/async_client/client.py
+++ b/courtlistener/async_client/client.py
@@ -8,6 +8,7 @@ import httpx
 from courtlistener.async_client.resource import AsyncResource
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.models import ENDPOINTS
+from courtlistener.settings import get_api_base_url
 
 if TYPE_CHECKING:
     from courtlistener.async_client.alerts import (
@@ -15,8 +16,6 @@ if TYPE_CHECKING:
         AsyncSearchAlerts,
     )
     from courtlistener.async_client.citation_lookup import AsyncCitationLookup
-
-DEFAULT_API_BASE_URL = "https://www.courtlistener.com/api/rest/v4"
 
 
 class AsyncCourtListener:
@@ -54,10 +53,7 @@ class AsyncCourtListener:
             )
 
         if base_url is None:
-            base_url = (
-                os.environ.get("COURTLISTENER_API_BASE_URL")
-                or DEFAULT_API_BASE_URL
-            )
+            base_url = get_api_base_url()
 
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout

--- a/courtlistener/settings.py
+++ b/courtlistener/settings.py
@@ -1,0 +1,10 @@
+import os
+
+DEFAULT_API_BASE_URL = "https://www.courtlistener.com/api/rest/v4"
+
+
+def get_api_base_url() -> str:
+    """Return the CourtListener REST API root, without a trailing slash."""
+    return (
+        os.environ.get("COURTLISTENER_API_BASE_URL") or DEFAULT_API_BASE_URL
+    ).rstrip("/")

--- a/courtlistener/sync_client/client.py
+++ b/courtlistener/sync_client/client.py
@@ -7,13 +7,12 @@ import httpx
 
 from courtlistener.exceptions import CourtListenerAPIError
 from courtlistener.models import ENDPOINTS
+from courtlistener.settings import get_api_base_url
 from courtlistener.sync_client.resource import Resource
 
 if TYPE_CHECKING:
     from courtlistener.sync_client.alerts import DocketAlerts, SearchAlerts
     from courtlistener.sync_client.citation_lookup import CitationLookup
-
-DEFAULT_API_BASE_URL = "https://www.courtlistener.com/api/rest/v4"
 
 
 class CourtListener:
@@ -51,10 +50,7 @@ class CourtListener:
             )
 
         if base_url is None:
-            base_url = (
-                os.environ.get("COURTLISTENER_API_BASE_URL")
-                or DEFAULT_API_BASE_URL
-            )
+            base_url = get_api_base_url()
 
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout


### PR DESCRIPTION
Fixes #244

We'll need to reference the base url in the MCP token verification when we add support for api tokens. Move the base url used by clients to settings so it will be easier to access when we do.