### PR TITLE
Prepare token verification for multiple token kinds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ The following changes are not yet released, but are code complete:
 
 Changes:
 - Add `courtlistener/settings.py` with `get_api_base_url()`, now the single source of truth for the CourtListener API root.
+- Cache a structured record of each verified token instead of a bare user hash, keyed by credential kind (`mcp:token_info:{kind}:{hmac}`), so an entry verified as one kind can never satisfy a lookup for another. Entries under the old `mcp:token_to_user:` namespace are ignored and re-verified once.
+- Token verification degrades to direct verification when the session store is unavailable, instead of turning a Redis blip into a 500 on every request.
 
 ### 1.2.0 - 2026-08-04
 

--- a/courtlistener/mcp/auth.py
+++ b/courtlistener/mcp/auth.py
@@ -9,47 +9,68 @@ from fastmcp.server.auth.auth import (
 from courtlistener.mcp.session import get_session, hmac_hex
 from courtlistener.mcp.settings import (
     OAUTH_USERINFO_URL,
-    USERINFO_TIMEOUT_SECONDS,
+    VERIFICATION_TIMEOUT_SECONDS,
 )
 
 logger = logging.getLogger(__name__)
 
+TOKEN_KIND_OAUTH = "oauth"
+TOKEN_KIND_API = "api_token"
 
-async def resolve_user_hash_via_userinfo(
-    token: str,
-) -> tuple[str | None, bool]:
-    """Verifies token from cache or via CL's `/o/userinfo/` endpoint."""
-    session = get_session()
-    cached = await session.get_user_hash(token)
-    if cached:
-        return cached, True
 
+async def verify_oauth_token(token: str) -> dict | None:
+    """Return token info if *token* is a valid OAuth access token."""
     try:
-        async with httpx.AsyncClient(timeout=USERINFO_TIMEOUT_SECONDS) as http:
+        async with httpx.AsyncClient(
+            timeout=VERIFICATION_TIMEOUT_SECONDS
+        ) as http:
             resp = await http.get(
                 OAUTH_USERINFO_URL,
                 headers={"Authorization": f"Bearer {token}"},
             )
     except httpx.HTTPError as exc:
         logger.warning("userinfo call failed: %s", exc)
-        return None, False
-
+        return None
     if resp.status_code != 200:
         # 401 from userinfo == revoked/expired/invalid. Don't cache.
-        return None, False
-
+        return None
     sub = resp.json().get("sub")
     if not sub:
         logger.warning("userinfo response missing `sub` claim")
-        return None, False
-
-    uh = hmac_hex(str(sub))
-    await session.store_user_hash(token, uh)
-    return uh, False
+        return None
+    return {"user_hash": hmac_hex(str(sub))}
 
 
-class UserInfoTokenVerifier(TokenVerifier):
-    """Verifies OAuth tokens via CL's `/o/userinfo/` endpoint."""
+async def resolve_token(token: str, *, kind: str) -> dict | None:
+    """Verify *token* as a credential of *kind*, or return ``None``."""
+    session = get_session()
+    try:
+        cached = await session.get_token_info(token, kind)
+    except Exception as exc:
+        logger.warning("token cache read failed; verifying directly: %s", exc)
+        cached = None
+
+    if cached:
+        return {**cached, "kind": kind, "cached": True}
+
+    if kind == TOKEN_KIND_OAUTH:
+        info = await verify_oauth_token(token)
+    else:
+        info = None
+        logger.warning("Token verification not implemented for %s", kind)
+    if info is None:
+        return None
+
+    logger.info("verified %s credential", kind)
+    try:
+        await session.store_token_info(token, kind, info)
+    except Exception as exc:
+        logger.warning("token cache write failed: %s", exc)
+    return {**info, "kind": kind, "cached": False}
+
+
+class CourtListenerTokenVerifier(TokenVerifier):
+    """Verify CourtListener tokens."""
 
     def __init__(self, *, base_url: str) -> None:
         super().__init__(
@@ -60,12 +81,17 @@ class UserInfoTokenVerifier(TokenVerifier):
     async def verify_token(self, token: str) -> AccessToken | None:
         if not token:
             return None
-        user_hash, from_cache = await resolve_user_hash_via_userinfo(token)
-        if user_hash is None:
+        # Hardcoded to OAuth until we add API token support.
+        info = await resolve_token(token, kind=TOKEN_KIND_OAUTH)
+        if info is None:
             return None
         return AccessToken(
             token=token,
             client_id="courtlistener-mcp",
             scopes=list(self.required_scopes),
-            claims={"user_hash": user_hash, "cached": from_cache},
+            claims={
+                "user_hash": info["user_hash"],
+                "token_kind": info["kind"],
+                "cached": info["cached"],
+            },
         )

--- a/courtlistener/mcp/auth.py
+++ b/courtlistener/mcp/auth.py
@@ -1,4 +1,5 @@
 import logging
+from typing import NoReturn
 
 import httpx
 from fastmcp.server.auth.auth import (
@@ -14,6 +15,11 @@ from courtlistener.mcp.settings import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _assert_unhandled_token_kind(value: NoReturn) -> NoReturn:
+    """Exhaustiveness guard for mypy."""
+    raise AssertionError(f"unhandled token kind: {value!r}")
 
 
 async def verify_oauth_token(token: str) -> TokenInfo | None:
@@ -58,6 +64,8 @@ async def resolve_token(
     elif kind == TokenKind.API:
         logger.warning("token verification not implemented for %s", kind)
         info = None
+    else:
+        _assert_unhandled_token_kind(kind)
     if info is None:
         return None
 

--- a/courtlistener/mcp/auth.py
+++ b/courtlistener/mcp/auth.py
@@ -6,6 +6,7 @@ from fastmcp.server.auth.auth import (
     TokenVerifier,
 )
 
+from courtlistener.mcp.auth_types import ResolvedToken, TokenInfo, TokenKind
 from courtlistener.mcp.session import get_session, hmac_hex
 from courtlistener.mcp.settings import (
     OAUTH_USERINFO_URL,
@@ -14,11 +15,8 @@ from courtlistener.mcp.settings import (
 
 logger = logging.getLogger(__name__)
 
-TOKEN_KIND_OAUTH = "oauth"
-TOKEN_KIND_API = "api_token"
 
-
-async def verify_oauth_token(token: str) -> dict | None:
+async def verify_oauth_token(token: str) -> TokenInfo | None:
     """Return token info if *token* is a valid OAuth access token."""
     try:
         async with httpx.AsyncClient(
@@ -38,10 +36,12 @@ async def verify_oauth_token(token: str) -> dict | None:
     if not sub:
         logger.warning("userinfo response missing `sub` claim")
         return None
-    return {"user_hash": hmac_hex(str(sub))}
+    return TokenInfo(user_hash=hmac_hex(str(sub)))
 
 
-async def resolve_token(token: str, *, kind: str) -> dict | None:
+async def resolve_token(
+    token: str, *, kind: TokenKind
+) -> ResolvedToken | None:
     """Verify *token* as a credential of *kind*, or return ``None``."""
     session = get_session()
     try:
@@ -51,13 +51,13 @@ async def resolve_token(token: str, *, kind: str) -> dict | None:
         cached = None
 
     if cached:
-        return {**cached, "kind": kind, "cached": True}
+        return ResolvedToken(**cached, kind=kind, cached=True)
 
-    if kind == TOKEN_KIND_OAUTH:
+    if kind == TokenKind.OAUTH:
         info = await verify_oauth_token(token)
-    else:
+    elif kind == TokenKind.API:
+        logger.warning("token verification not implemented for %s", kind)
         info = None
-        logger.warning("Token verification not implemented for %s", kind)
     if info is None:
         return None
 
@@ -66,7 +66,7 @@ async def resolve_token(token: str, *, kind: str) -> dict | None:
         await session.store_token_info(token, kind, info)
     except Exception as exc:
         logger.warning("token cache write failed: %s", exc)
-    return {**info, "kind": kind, "cached": False}
+    return ResolvedToken(**info, kind=kind, cached=False)
 
 
 class CourtListenerTokenVerifier(TokenVerifier):
@@ -82,7 +82,7 @@ class CourtListenerTokenVerifier(TokenVerifier):
         if not token:
             return None
         # Hardcoded to OAuth until we add API token support.
-        info = await resolve_token(token, kind=TOKEN_KIND_OAUTH)
+        info = await resolve_token(token, kind=TokenKind.OAUTH)
         if info is None:
             return None
         return AccessToken(

--- a/courtlistener/mcp/auth_types.py
+++ b/courtlistener/mcp/auth_types.py
@@ -1,0 +1,24 @@
+from enum import Enum
+from typing import TypedDict
+
+
+class TokenKind(str, Enum):
+    """A kind of credential the server knows how to verify."""
+
+    OAUTH = "oauth"
+    API = "api_token"
+
+    __str__ = str.__str__
+
+
+class TokenInfo(TypedDict):
+    """A verified credential, as persisted in the session store."""
+
+    user_hash: str
+
+
+class ResolvedToken(TokenInfo):
+    """A stored ``TokenInfo`` plus per-request resolution metadata."""
+
+    kind: TokenKind
+    cached: bool

--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -11,6 +11,7 @@ from courtlistener.exceptions import (
     CourtListenerAPIError,
     InvalidFieldsError,
 )
+from courtlistener.mcp.auth import TOKEN_KIND_OAUTH
 from courtlistener.mcp.exceptions import (
     SentryExemptToolError,
     ToolArgumentValidationError,
@@ -53,7 +54,12 @@ class ToolHandlerMiddleware(Middleware):
                 except RuntimeError:
                     access_token = None
                 if access_token is not None:
-                    await get_session().invalidate_token(access_token.token)
+                    await get_session().invalidate_token(
+                        access_token.token,
+                        access_token.claims.get(
+                            "token_kind", TOKEN_KIND_OAUTH
+                        ),
+                    )
                 message = (
                     "CourtListener rejected the request as unauthorized. "
                     "Your session may have expired; retry to re-authenticate."

--- a/courtlistener/mcp/middleware.py
+++ b/courtlistener/mcp/middleware.py
@@ -11,7 +11,7 @@ from courtlistener.exceptions import (
     CourtListenerAPIError,
     InvalidFieldsError,
 )
-from courtlistener.mcp.auth import TOKEN_KIND_OAUTH
+from courtlistener.mcp.auth_types import TokenKind
 from courtlistener.mcp.exceptions import (
     SentryExemptToolError,
     ToolArgumentValidationError,
@@ -56,9 +56,7 @@ class ToolHandlerMiddleware(Middleware):
                 if access_token is not None:
                     await get_session().invalidate_token(
                         access_token.token,
-                        access_token.claims.get(
-                            "token_kind", TOKEN_KIND_OAUTH
-                        ),
+                        access_token.claims.get("token_kind", TokenKind.OAUTH),
                     )
                 message = (
                     "CourtListener rejected the request as unauthorized. "

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -19,7 +19,7 @@ from starlette.responses import (
 from starlette.routing import Route
 
 from courtlistener.mcp import settings
-from courtlistener.mcp.auth import UserInfoTokenVerifier
+from courtlistener.mcp.auth import CourtListenerTokenVerifier
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
 from courtlistener.mcp.prompts import GLOBAL_INSTRUCTIONS
 from courtlistener.mcp.settings import (
@@ -135,7 +135,7 @@ def build_auth() -> AuthProvider | None:
     if not settings.MCP_REQUIRE_OAUTH:
         return None
     return RemoteAuthProvider(
-        token_verifier=UserInfoTokenVerifier(base_url=MCP_BASE_URL),
+        token_verifier=CourtListenerTokenVerifier(base_url=MCP_BASE_URL),
         authorization_servers=[AnyHttpUrl(OAUTH_ISSUER)],
         base_url=MCP_BASE_URL,
     )

--- a/courtlistener/mcp/session.py
+++ b/courtlistener/mcp/session.py
@@ -13,6 +13,7 @@ from fastmcp.server.dependencies import get_access_token
 
 from courtlistener import CourtListener
 from courtlistener.mcp import settings
+from courtlistener.mcp.auth_types import TokenInfo, TokenKind
 from courtlistener.mcp.settings import (
     DOCUMENT_TTL_SECONDS,
     MCP_SECRET_BYTES,
@@ -35,7 +36,7 @@ def hmac_hex(value: str) -> str:
     ).hexdigest()
 
 
-def token_info_key(token: str, kind: str) -> str:
+def token_info_key(token: str, kind: TokenKind) -> str:
     """Cache key for a verified credential."""
     return f"mcp:token_info:{kind}:{hmac_hex(token)}"
 
@@ -118,7 +119,9 @@ class Session:
             f"mcp:doc:{doc_type}:{doc_id}", text, DOCUMENT_TTL_SECONDS
         )
 
-    async def get_token_info(self, token: str, kind: str) -> dict | None:
+    async def get_token_info(
+        self, token: str, kind: TokenKind
+    ) -> TokenInfo | None:
         """Return the cached verification of *token* as a *kind* credential."""
         raw = await self._get(token_info_key(token, kind))
         if raw is None:
@@ -126,7 +129,7 @@ class Session:
         return json.loads(raw)
 
     async def store_token_info(
-        self, token: str, kind: str, info: dict
+        self, token: str, kind: TokenKind, info: TokenInfo
     ) -> None:
         await self._set(
             token_info_key(token, kind),
@@ -134,7 +137,7 @@ class Session:
             TOKEN_CACHE_TTL_SECONDS,
         )
 
-    async def invalidate_token(self, token: str, kind: str) -> None:
+    async def invalidate_token(self, token: str, kind: TokenKind) -> None:
         """Drop a cached token verification."""
         try:
             await self._delete(token_info_key(token, kind))

--- a/courtlistener/mcp/session.py
+++ b/courtlistener/mcp/session.py
@@ -35,6 +35,11 @@ def hmac_hex(value: str) -> str:
     ).hexdigest()
 
 
+def token_info_key(token: str, kind: str) -> str:
+    """Cache key for a verified credential."""
+    return f"mcp:token_info:{kind}:{hmac_hex(token)}"
+
+
 def user_hash(client: CourtListener) -> str:
     """Return the stable per-user key prefix for the current request."""
     try:
@@ -113,24 +118,26 @@ class Session:
             f"mcp:doc:{doc_type}:{doc_id}", text, DOCUMENT_TTL_SECONDS
         )
 
-    async def get_token_info(self, token: str) -> dict | None:
-        """Return cached ``{"kind": ..., "user_hash": ...}`` for *token*."""
-        raw = await self._get(f"mcp:token_info:{hmac_hex(token)}")
+    async def get_token_info(self, token: str, kind: str) -> dict | None:
+        """Return the cached verification of *token* as a *kind* credential."""
+        raw = await self._get(token_info_key(token, kind))
         if raw is None:
             return None
         return json.loads(raw)
 
-    async def store_token_info(self, token: str, info: dict) -> None:
+    async def store_token_info(
+        self, token: str, kind: str, info: dict
+    ) -> None:
         await self._set(
-            f"mcp:token_info:{hmac_hex(token)}",
+            token_info_key(token, kind),
             json.dumps(info),
             TOKEN_CACHE_TTL_SECONDS,
         )
 
-    async def invalidate_token(self, token: str) -> None:
+    async def invalidate_token(self, token: str, kind: str) -> None:
         """Drop a cached token verification."""
         try:
-            await self._delete(f"mcp:token_info:{hmac_hex(token)}")
+            await self._delete(token_info_key(token, kind))
         except Exception as exc:
             logger.warning("failed to invalidate token cache: %s", exc)
 

--- a/courtlistener/mcp/session.py
+++ b/courtlistener/mcp/session.py
@@ -113,20 +113,24 @@ class Session:
             f"mcp:doc:{doc_type}:{doc_id}", text, DOCUMENT_TTL_SECONDS
         )
 
-    async def get_user_hash(self, token: str) -> str | None:
-        return await self._get(f"mcp:token_to_user:{hmac_hex(token)}")
+    async def get_token_info(self, token: str) -> dict | None:
+        """Return cached ``{"kind": ..., "user_hash": ...}`` for *token*."""
+        raw = await self._get(f"mcp:token_info:{hmac_hex(token)}")
+        if raw is None:
+            return None
+        return json.loads(raw)
 
-    async def store_user_hash(self, token: str, uh: str) -> None:
+    async def store_token_info(self, token: str, info: dict) -> None:
         await self._set(
-            f"mcp:token_to_user:{hmac_hex(token)}",
-            uh,
+            f"mcp:token_info:{hmac_hex(token)}",
+            json.dumps(info),
             TOKEN_CACHE_TTL_SECONDS,
         )
 
     async def invalidate_token(self, token: str) -> None:
-        """Drop a token to user_hash mapping."""
+        """Drop a cached token verification."""
         try:
-            await self._delete(f"mcp:token_to_user:{hmac_hex(token)}")
+            await self._delete(f"mcp:token_info:{hmac_hex(token)}")
         except Exception as exc:
             logger.warning("failed to invalidate token cache: %s", exc)
 

--- a/courtlistener/mcp/settings.py
+++ b/courtlistener/mcp/settings.py
@@ -41,7 +41,7 @@ SENTRY_TRACES_SAMPLE_RATE = float(
     os.getenv("SENTRY_TRACES_SAMPLE_RATE") or 0.02
 )
 
-# How long a token to user_hash mapping is cached.
+# How long a verified token's info is cached.
 TOKEN_CACHE_TTL_SECONDS = int(os.getenv("MCP_TOKEN_CACHE_TTL", "600"))
 
 # Whether the HTTP app requires OAuth.
@@ -53,8 +53,8 @@ SESSION_TTL_SECONDS = 3600  # 1 hour
 # How long a cached document lives in the session store (shared across users).
 DOCUMENT_TTL_SECONDS = 86400  # 24 hours
 
-# Timeout for the userinfo call made during token verification.
-USERINFO_TIMEOUT_SECONDS = 10
+# Timeout for the upstream calls made during token verification.
+VERIFICATION_TIMEOUT_SECONDS = 20
 
 # Result-count bounds for search/list tools.
 DEFAULT_NUM_RESULTS = 20

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -475,7 +475,7 @@ class TestUserHash:
 
     def test_reads_claim_from_oauth_context(self):
         """With a FastMCP access token in scope carrying a ``user_hash``
-        claim (populated by ``UserInfoTokenVerifier``), ``user_hash``
+        claim (populated by ``CourtListenerTokenVerifier``), ``user_hash``
         returns the claim verbatim. Rotating the access token doesn't
         change the hash because the claim is derived from the stable
         OIDC ``sub``.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,15 +1,28 @@
 """Tests for authentication plumbing: Bearer vs Token headers in
-``CourtListener.client`` and the three-way resolution in
-``MCPTool.get_client``.
+``CourtListener.client``, the three-way resolution in
+``MCPTool.get_client``, token resolution and caching in
+``resolve_token``, and the server's auth wiring.
 """
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from courtlistener import CourtListener
+from courtlistener.mcp.auth import (
+    TOKEN_KIND_API,
+    TOKEN_KIND_OAUTH,
+    CourtListenerTokenVerifier,
+    resolve_token,
+)
+from courtlistener.mcp.session import InMemorySession, get_session, set_session
+
+
+def run(coro):
+    return asyncio.run(coro)
 
 
 class TestClientAuthHeader:
@@ -153,6 +166,104 @@ class TestMCPToolGetClient:
         assert cl.client.headers["Authorization"] == "Token env-api-token"
 
 
+class TestResolveToken:
+    """``resolve_token`` sits between the verifier and the session
+    store: it serves a cached verification when one exists for that
+    credential kind, and otherwise verifies and caches."""
+
+    @pytest.fixture(autouse=True)
+    def fresh_session(self):
+        set_session(InMemorySession())
+        yield
+        set_session(None)
+
+    def test_verifies_and_caches_on_a_miss(self):
+        verify = AsyncMock(return_value={"user_hash": "uh"})
+        with patch("courtlistener.mcp.auth.verify_oauth_token", new=verify):
+            info = run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+        assert info == {
+            "user_hash": "uh",
+            "kind": TOKEN_KIND_OAUTH,
+            "cached": False,
+        }
+        assert run(get_session().get_token_info("tok", TOKEN_KIND_OAUTH)) == {
+            "user_hash": "uh"
+        }
+
+    def test_kind_and_cached_are_not_persisted(self):
+        """``kind`` already lives in the cache key, and ``cached`` is
+        per-request state for the middleware — neither belongs in the
+        stored record."""
+        verify = AsyncMock(return_value={"user_hash": "uh"})
+        with patch("courtlistener.mcp.auth.verify_oauth_token", new=verify):
+            run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+        stored = run(get_session().get_token_info("tok", TOKEN_KIND_OAUTH))
+        assert stored == {"user_hash": "uh"}
+
+    def test_cache_hit_skips_verification(self):
+        verify = AsyncMock(return_value={"user_hash": "uh"})
+        with patch("courtlistener.mcp.auth.verify_oauth_token", new=verify):
+            run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+            info = run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+        assert verify.await_count == 1
+        assert info["cached"] is True
+        assert info["user_hash"] == "uh"
+
+    def test_a_cached_entry_does_not_cross_credential_kinds(self):
+        """The kind is part of the cache key, so an entry verified as
+        one kind can't satisfy a lookup for another. Without that, a
+        warm entry would let a credential in under the wrong scheme."""
+        verify = AsyncMock(return_value={"user_hash": "uh"})
+        with patch("courtlistener.mcp.auth.verify_oauth_token", new=verify):
+            run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+            # No verifier exists for this kind yet, so a cache hit is
+            # the only way it could resolve — and it must not.
+            assert run(resolve_token("tok", kind=TOKEN_KIND_API)) is None
+
+    def test_unimplemented_kind_returns_none(self):
+        assert run(resolve_token("tok", kind=TOKEN_KIND_API)) is None
+
+    def test_failed_verification_is_not_cached(self):
+        with patch(
+            "courtlistener.mcp.auth.verify_oauth_token",
+            new=AsyncMock(return_value=None),
+        ):
+            assert run(resolve_token("tok", kind=TOKEN_KIND_OAUTH)) is None
+        assert (
+            run(get_session().get_token_info("tok", TOKEN_KIND_OAUTH)) is None
+        )
+
+    def test_cache_read_failure_degrades_to_direct_verification(self):
+        """A session-store outage must not turn every request into a
+        500 — verification carries on without the cache."""
+
+        class ExplodingSession(InMemorySession):
+            async def _get(self, key):
+                raise ConnectionError("redis down")
+
+        set_session(ExplodingSession())
+        with patch(
+            "courtlistener.mcp.auth.verify_oauth_token",
+            new=AsyncMock(return_value={"user_hash": "uh"}),
+        ):
+            info = run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+        assert info is not None
+        assert info["user_hash"] == "uh"
+
+    def test_cache_write_failure_does_not_escape(self):
+        class ExplodingSession(InMemorySession):
+            async def _set(self, key, value, ttl_seconds):
+                raise ConnectionError("redis down")
+
+        set_session(ExplodingSession())
+        with patch(
+            "courtlistener.mcp.auth.verify_oauth_token",
+            new=AsyncMock(return_value={"user_hash": "uh"}),
+        ):
+            info = run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+        assert info is not None
+
+
 class TestServerAuthWiring:
     """``build_auth`` activates when ``MCP_REQUIRE_OAUTH`` is set to "true",
     and ``create_mcp_server`` itself never pulls auth from the
@@ -160,10 +271,10 @@ class TestServerAuthWiring:
 
     def test_build_auth_returns_verifier_when_set(self):
         """OAuth on → returns a RemoteAuthProvider that publishes the
-        RFC 9728 protected-resource metadata, wrapping the userinfo
-        verifier. Tokens are now validated via CL's OIDC userinfo
-        endpoint, and the resolved user_hash is cached in Redis so
-        session state survives access-token rotation.
+        RFC 9728 protected-resource metadata, wrapping the CourtListener
+        verifier. Tokens are validated via CL's OIDC userinfo endpoint,
+        and the resolved user_hash is cached in Redis so session state
+        survives access-token rotation.
         """
         from fastmcp.server.auth.auth import RemoteAuthProvider
 
@@ -186,7 +297,7 @@ class TestServerAuthWiring:
             importlib.reload(settings_mod)
             importlib.reload(server_mod)
             auth = server_mod.build_auth()
-            verifier_cls = server_mod.UserInfoTokenVerifier
+            verifier_cls = server_mod.CourtListenerTokenVerifier
         assert isinstance(auth, RemoteAuthProvider)
         assert isinstance(auth.token_verifier, verifier_cls)
         # Discovery route is advertised so clients can find the auth
@@ -196,85 +307,110 @@ class TestServerAuthWiring:
         paths = {getattr(r, "path", None) for r in routes}
         assert "/.well-known/oauth-protected-resource" in paths
 
-    def test_userinfo_verifier_declares_openid_and_api_scopes(self):
+    def test_verifier_declares_openid_and_api_scopes(self):
         """Required scopes must appear on the verifier so they're
         advertised in protected-resource metadata and MCP clients
         include them in the authorize request. ``openid`` is what
         makes userinfo accept the token at all; ``api`` is what CL's
         REST API expects downstream.
         """
-        from courtlistener.mcp.auth import UserInfoTokenVerifier
-
-        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
+        verifier = CourtListenerTokenVerifier(
+            base_url="https://mcp.example.test"
+        )
         assert set(verifier.required_scopes) == {"openid", "api"}
 
-    def test_userinfo_verifier_accepts_when_userinfo_succeeds(self):
-        """Successful userinfo lookup → AccessToken carrying the
-        resolved ``user_hash`` in its claims, plus the required scopes
+    def test_verifier_accepts_a_resolved_token(self):
+        """Successful resolution → AccessToken carrying the user_hash
+        and the credential kind in its claims, plus the required scopes
         echoed back so the middleware's scope check passes.
         """
-        import asyncio
-
-        from courtlistener.mcp.auth import UserInfoTokenVerifier
-
-        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
+        verifier = CourtListenerTokenVerifier(
+            base_url="https://mcp.example.test"
+        )
         with patch(
-            "courtlistener.mcp.auth.resolve_user_hash_via_userinfo",
-            new=AsyncMock(return_value=("fake-user-hash", False)),
+            "courtlistener.mcp.auth.resolve_token",
+            new=AsyncMock(
+                return_value={
+                    "user_hash": "fake-user-hash",
+                    "kind": TOKEN_KIND_OAUTH,
+                    "cached": False,
+                }
+            ),
         ):
-            token = asyncio.run(verifier.verify_token("anything-goes"))
+            token = run(verifier.verify_token("anything-goes"))
         assert token is not None
         assert token.token == "anything-goes"
         assert token.claims.get("user_hash") == "fake-user-hash"
+        assert token.claims.get("token_kind") == TOKEN_KIND_OAUTH
         assert token.claims.get("cached") is False
         assert set(token.scopes) == {"openid", "api"}
 
-    def test_userinfo_verifier_marks_cache_hits(self):
+    def test_verifier_asks_for_an_oauth_credential(self):
+        """Bearer is the only scheme the SDK lets through today, so the
+        verifier resolves against OAuth until API tokens are added."""
+        verifier = CourtListenerTokenVerifier(
+            base_url="https://mcp.example.test"
+        )
+        resolve = AsyncMock(
+            return_value={
+                "user_hash": "h",
+                "kind": TOKEN_KIND_OAUTH,
+                "cached": False,
+            }
+        )
+        with patch("courtlistener.mcp.auth.resolve_token", new=resolve):
+            run(verifier.verify_token("jwt"))
+        resolve.assert_awaited_once_with("jwt", kind=TOKEN_KIND_OAUTH)
+
+    def test_verifier_marks_cache_hits(self):
         """A cache-served verification is flagged in the claims so the
         middleware can triage downstream 401s (routine rotation vs.
         AS/API disagreement)."""
-        import asyncio
-
-        from courtlistener.mcp.auth import UserInfoTokenVerifier
-
-        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
+        verifier = CourtListenerTokenVerifier(
+            base_url="https://mcp.example.test"
+        )
         with patch(
-            "courtlistener.mcp.auth.resolve_user_hash_via_userinfo",
-            new=AsyncMock(return_value=("fake-user-hash", True)),
+            "courtlistener.mcp.auth.resolve_token",
+            new=AsyncMock(
+                return_value={
+                    "user_hash": "fake-user-hash",
+                    "kind": TOKEN_KIND_OAUTH,
+                    "cached": True,
+                }
+            ),
         ):
-            token = asyncio.run(verifier.verify_token("cached-token"))
+            token = run(verifier.verify_token("cached-token"))
         assert token is not None
         assert token.claims.get("cached") is True
 
-    def test_userinfo_verifier_rejects_when_userinfo_fails(self):
-        """Userinfo returning ``None`` (401/non-200/network error) →
+    def test_verifier_rejects_an_unresolvable_token(self):
+        """Resolution returning ``None`` (401/non-200/network error) →
         ``verify_token`` returns ``None``, which the auth middleware
         converts into a proper HTTP 401 with ``WWW-Authenticate`` so
         the MCP client re-runs OAuth.
         """
-        import asyncio
-
-        from courtlistener.mcp.auth import UserInfoTokenVerifier
-
-        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
+        verifier = CourtListenerTokenVerifier(
+            base_url="https://mcp.example.test"
+        )
         with patch(
-            "courtlistener.mcp.auth.resolve_user_hash_via_userinfo",
-            new=AsyncMock(return_value=(None, False)),
+            "courtlistener.mcp.auth.resolve_token",
+            new=AsyncMock(return_value=None),
         ):
-            token = asyncio.run(verifier.verify_token("revoked-or-bad"))
+            token = run(verifier.verify_token("revoked-or-bad"))
         assert token is None
 
-    def test_userinfo_verifier_rejects_empty_token(self):
-        """Empty bearer → short-circuit without calling userinfo.
-        Prevents trivially-empty ``Authorization: Bearer`` headers from
-        consuming a round-trip to CL.
+    def test_verifier_rejects_empty_token(self):
+        """Empty bearer → short-circuit without touching the cache or
+        userinfo. Prevents trivially-empty ``Authorization: Bearer``
+        headers from consuming a round-trip to CL.
         """
-        import asyncio
-
-        from courtlistener.mcp.auth import UserInfoTokenVerifier
-
-        verifier = UserInfoTokenVerifier(base_url="https://mcp.example.test")
-        assert asyncio.run(verifier.verify_token("")) is None
+        verifier = CourtListenerTokenVerifier(
+            base_url="https://mcp.example.test"
+        )
+        resolve = AsyncMock()
+        with patch("courtlistener.mcp.auth.resolve_token", new=resolve):
+            assert run(verifier.verify_token("")) is None
+        resolve.assert_not_awaited()
 
     def test_build_auth_respects_require_oauth_setting(self):
         """``build_auth`` reads ``settings.MCP_REQUIRE_OAUTH`` at call

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,11 +13,10 @@ import pytest
 
 from courtlistener import CourtListener
 from courtlistener.mcp.auth import (
-    TOKEN_KIND_API,
-    TOKEN_KIND_OAUTH,
     CourtListenerTokenVerifier,
     resolve_token,
 )
+from courtlistener.mcp.auth_types import TokenKind
 from courtlistener.mcp.session import InMemorySession, get_session, set_session
 
 
@@ -180,13 +179,13 @@ class TestResolveToken:
     def test_verifies_and_caches_on_a_miss(self):
         verify = AsyncMock(return_value={"user_hash": "uh"})
         with patch("courtlistener.mcp.auth.verify_oauth_token", new=verify):
-            info = run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+            info = run(resolve_token("tok", kind=TokenKind.OAUTH))
         assert info == {
             "user_hash": "uh",
-            "kind": TOKEN_KIND_OAUTH,
+            "kind": TokenKind.OAUTH,
             "cached": False,
         }
-        assert run(get_session().get_token_info("tok", TOKEN_KIND_OAUTH)) == {
+        assert run(get_session().get_token_info("tok", TokenKind.OAUTH)) == {
             "user_hash": "uh"
         }
 
@@ -196,15 +195,15 @@ class TestResolveToken:
         stored record."""
         verify = AsyncMock(return_value={"user_hash": "uh"})
         with patch("courtlistener.mcp.auth.verify_oauth_token", new=verify):
-            run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
-        stored = run(get_session().get_token_info("tok", TOKEN_KIND_OAUTH))
+            run(resolve_token("tok", kind=TokenKind.OAUTH))
+        stored = run(get_session().get_token_info("tok", TokenKind.OAUTH))
         assert stored == {"user_hash": "uh"}
 
     def test_cache_hit_skips_verification(self):
         verify = AsyncMock(return_value={"user_hash": "uh"})
         with patch("courtlistener.mcp.auth.verify_oauth_token", new=verify):
-            run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
-            info = run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+            run(resolve_token("tok", kind=TokenKind.OAUTH))
+            info = run(resolve_token("tok", kind=TokenKind.OAUTH))
         assert verify.await_count == 1
         assert info["cached"] is True
         assert info["user_hash"] == "uh"
@@ -215,22 +214,36 @@ class TestResolveToken:
         warm entry would let a credential in under the wrong scheme."""
         verify = AsyncMock(return_value={"user_hash": "uh"})
         with patch("courtlistener.mcp.auth.verify_oauth_token", new=verify):
-            run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+            run(resolve_token("tok", kind=TokenKind.OAUTH))
             # No verifier exists for this kind yet, so a cache hit is
             # the only way it could resolve — and it must not.
-            assert run(resolve_token("tok", kind=TOKEN_KIND_API)) is None
+            assert run(resolve_token("tok", kind=TokenKind.API)) is None
 
     def test_unimplemented_kind_returns_none(self):
-        assert run(resolve_token("tok", kind=TOKEN_KIND_API)) is None
+        assert run(resolve_token("tok", kind=TokenKind.API)) is None
+
+    @pytest.mark.parametrize("kind", list(TokenKind))
+    def test_every_declared_kind_is_dispatched(self, kind):
+        """Adding a ``TokenKind`` without a verifier branch is a mypy
+        error at ``_assert_never``, but that only helps where mypy runs.
+        At runtime every declared kind must still either resolve or fail
+        closed — never raise its way out of the auth path as a 500.
+        """
+        with patch(
+            "courtlistener.mcp.auth.verify_oauth_token",
+            new=AsyncMock(return_value={"user_hash": "uh"}),
+        ):
+            info = run(resolve_token("tok", kind=kind))
+        assert info is None or info["user_hash"] == "uh"
 
     def test_failed_verification_is_not_cached(self):
         with patch(
             "courtlistener.mcp.auth.verify_oauth_token",
             new=AsyncMock(return_value=None),
         ):
-            assert run(resolve_token("tok", kind=TOKEN_KIND_OAUTH)) is None
+            assert run(resolve_token("tok", kind=TokenKind.OAUTH)) is None
         assert (
-            run(get_session().get_token_info("tok", TOKEN_KIND_OAUTH)) is None
+            run(get_session().get_token_info("tok", TokenKind.OAUTH)) is None
         )
 
     def test_cache_read_failure_degrades_to_direct_verification(self):
@@ -246,7 +259,7 @@ class TestResolveToken:
             "courtlistener.mcp.auth.verify_oauth_token",
             new=AsyncMock(return_value={"user_hash": "uh"}),
         ):
-            info = run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+            info = run(resolve_token("tok", kind=TokenKind.OAUTH))
         assert info is not None
         assert info["user_hash"] == "uh"
 
@@ -260,7 +273,7 @@ class TestResolveToken:
             "courtlistener.mcp.auth.verify_oauth_token",
             new=AsyncMock(return_value={"user_hash": "uh"}),
         ):
-            info = run(resolve_token("tok", kind=TOKEN_KIND_OAUTH))
+            info = run(resolve_token("tok", kind=TokenKind.OAUTH))
         assert info is not None
 
 
@@ -332,7 +345,7 @@ class TestServerAuthWiring:
             new=AsyncMock(
                 return_value={
                     "user_hash": "fake-user-hash",
-                    "kind": TOKEN_KIND_OAUTH,
+                    "kind": TokenKind.OAUTH,
                     "cached": False,
                 }
             ),
@@ -341,7 +354,7 @@ class TestServerAuthWiring:
         assert token is not None
         assert token.token == "anything-goes"
         assert token.claims.get("user_hash") == "fake-user-hash"
-        assert token.claims.get("token_kind") == TOKEN_KIND_OAUTH
+        assert token.claims.get("token_kind") == TokenKind.OAUTH
         assert token.claims.get("cached") is False
         assert set(token.scopes) == {"openid", "api"}
 
@@ -354,13 +367,13 @@ class TestServerAuthWiring:
         resolve = AsyncMock(
             return_value={
                 "user_hash": "h",
-                "kind": TOKEN_KIND_OAUTH,
+                "kind": TokenKind.OAUTH,
                 "cached": False,
             }
         )
         with patch("courtlistener.mcp.auth.resolve_token", new=resolve):
             run(verifier.verify_token("jwt"))
-        resolve.assert_awaited_once_with("jwt", kind=TOKEN_KIND_OAUTH)
+        resolve.assert_awaited_once_with("jwt", kind=TokenKind.OAUTH)
 
     def test_verifier_marks_cache_hits(self):
         """A cache-served verification is flagged in the claims so the
@@ -374,7 +387,7 @@ class TestServerAuthWiring:
             new=AsyncMock(
                 return_value={
                     "user_hash": "fake-user-hash",
-                    "kind": TOKEN_KIND_OAUTH,
+                    "kind": TokenKind.OAUTH,
                     "cached": True,
                 }
             ),

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -67,7 +67,11 @@ class TestMiddlewareErrorClassification:
     def _fake_access_token(self, monkeypatch, cached):
         token = MagicMock()
         token.token = "tok"
-        token.claims = {"user_hash": "uh", "cached": cached}
+        token.claims = {
+            "user_hash": "uh",
+            "token_kind": "oauth",
+            "cached": cached,
+        }
         monkeypatch.setattr(
             "courtlistener.mcp.middleware.get_access_token", lambda: token
         )
@@ -87,7 +91,7 @@ class TestMiddlewareErrorClassification:
         with pytest.raises(SentryExemptToolError) as excinfo:
             await _call_tool_raising(monkeypatch, error)
         assert "retry to re-authenticate" in str(excinfo.value)
-        session.invalidate_token.assert_awaited_once_with("tok")
+        session.invalidate_token.assert_awaited_once_with("tok", "oauth")
 
     @pytest.mark.asyncio
     async def test_401_on_freshly_verified_token_reports(self, monkeypatch):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from courtlistener import CourtListener
+from courtlistener.mcp.auth_types import TokenKind
 from courtlistener.mcp.session import (
     InMemorySession,
     RedisSession,
@@ -136,6 +137,21 @@ class TestSessionDomainMethods:
         raw = run(session._get(token_info_key("tok", "oauth")))
         assert json.loads(raw) == info
         assert run(session.get_token_info("tok", "oauth")) == info
+
+    def test_token_kind_interpolates_as_its_bare_value(self):
+        """``TokenKind`` members reach the cache key through an f-string,
+        so a member and its bare value must build the same key. Python
+        3.11 changed mixed-in ``Enum.__format__`` to follow ``__str__``;
+        without pinning both to ``str``'s, keys would silently become
+        ``mcp:token_info:TokenKind.OAUTH:…`` there and orphan every entry
+        written under a different interpreter.
+        """
+        assert f"{TokenKind.OAUTH}" == "oauth"
+        assert str(TokenKind.API) == "api_token"
+        assert token_info_key("tok", TokenKind.OAUTH) == token_info_key(
+            "tok", "oauth"
+        )
+        assert ":oauth:" in token_info_key("tok", TokenKind.OAUTH)
 
     def test_token_cache_does_not_cross_credential_kinds(self):
         """An entry verified as one kind must never satisfy a lookup for

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,6 +6,7 @@ shared by both backends.
 from __future__ import annotations
 
 import asyncio
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,6 +18,7 @@ from courtlistener.mcp.session import (
     Session,
     get_session,
     set_session,
+    token_info_key,
 )
 
 
@@ -119,14 +121,48 @@ class TestSessionDomainMethods:
 
     def test_token_cache_roundtrip_and_invalidate(self):
         session = InMemorySession()
-        run(session.store_user_hash("tok", "hash123"))
-        assert run(session.get_user_hash("tok")) == "hash123"
-        run(session.invalidate_token("tok"))
-        assert run(session.get_user_hash("tok")) is None
+        info = {"user_hash": "hash123"}
+        run(session.store_token_info("tok", "oauth", info))
+        assert run(session.get_token_info("tok", "oauth")) == info
+        run(session.invalidate_token("tok", "oauth"))
+        assert run(session.get_token_info("tok", "oauth")) is None
+
+    def test_token_info_survives_a_json_roundtrip(self):
+        """The cache holds a structured record rather than a bare hash,
+        so it has room for more than ``user_hash`` later."""
+        session = InMemorySession()
+        info = {"user_hash": "hash123", "extra": ["a", 1, None]}
+        run(session.store_token_info("tok", "oauth", info))
+        raw = run(session._get(token_info_key("tok", "oauth")))
+        assert json.loads(raw) == info
+        assert run(session.get_token_info("tok", "oauth")) == info
+
+    def test_token_cache_does_not_cross_credential_kinds(self):
+        """An entry verified as one kind must never satisfy a lookup for
+        another — otherwise one valid request would warm a cache entry
+        that a different credential type could then ride in on."""
+        session = InMemorySession()
+        run(session.store_token_info("tok", "oauth", {"user_hash": "h"}))
+        assert run(session.get_token_info("tok", "api_token")) is None
+        assert run(session.get_token_info("tok", "oauth")) is not None
+
+    def test_invalidating_one_kind_leaves_the_other(self):
+        session = InMemorySession()
+        run(session.store_token_info("tok", "oauth", {"user_hash": "h1"}))
+        run(session.store_token_info("tok", "api_token", {"user_hash": "h2"}))
+        run(session.invalidate_token("tok", "oauth"))
+        assert run(session.get_token_info("tok", "oauth")) is None
+        assert run(session.get_token_info("tok", "api_token")) == {
+            "user_hash": "h2"
+        }
 
     def test_token_never_stored_in_plaintext(self):
         session = InMemorySession()
-        run(session.store_user_hash("secret-token", "hash123"))
+        run(
+            session.store_token_info(
+                "secret-token", "oauth", {"user_hash": "hash123"}
+            )
+        )
         assert not any("secret-token" in key for key in session._data)
 
     def test_invalidate_token_swallows_backend_errors(self):
@@ -134,7 +170,7 @@ class TestSessionDomainMethods:
             async def _delete(self, key):
                 raise RuntimeError("backend down")
 
-        run(ExplodingSession().invalidate_token("tok"))
+        run(ExplodingSession().invalidate_token("tok", "oauth"))
 
     def test_values_must_be_json_serializable(self, client):
         """Both backends JSON-round-trip, so non-serializable session


### PR DESCRIPTION
Fixes #246 

This PR prepares the token verification for multiple token kinds. Currently only oauth tokens are supported but this lays the groundwork for api token support:
- The token verification is refactored in auth. `resolve_token` now handles the steps that will be common to different verification methods (checking the cache, returning the formatted `info`), while the oauth token verification has been exported to `verify_oauth_token`.
- Relevant class names and settings vars have been updated to be more neutral wrt "verification" rather than oauth-specific.
- Cached verifications now store structured data instead of just the user hash, and the redis key is now namespaced by token kind. The motivation to store structured data drifts from the referenced issue as we originally planned to store the kind in the value here -- now we are only storing the user hash. So the move to structured data is somewhat trivial, but I'm keeping it since we may want to store more here in the future.
- Updates tests to use the new session pattern for token info.
- Also adds typed dicts for auth types so mypy can detect unhandled token kinds