### PR TITLE
feat(tools): Set openWorldHint false for tools that only make calls to CL API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Changes:
 - Add `courtlistener/settings.py` with `get_api_base_url()`, now the single source of truth for the CourtListener API root.
 - Cache a structured record of each verified token instead of a bare user hash, keyed by credential kind (`mcp:token_info:{kind}:{hmac}`), so an entry verified as one kind can never satisfy a lookup for another. Entries under the old `mcp:token_to_user:` namespace are ignored and re-verified once.
 - Token verification degrades to direct verification when the session store is unavailable, instead of turning a Redis blip into a 500 on every request.
+- Tools that only make CL API calls have been changed to have `openWorldHint=True`.
 
 ### 1.2.0 - 2026-08-04
 

--- a/courtlistener/mcp/tools/analyze_citations_tool.py
+++ b/courtlistener/mcp/tools/analyze_citations_tool.py
@@ -61,7 +61,7 @@ class AnalyzeCitationsTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/courtlistener/mcp/tools/call_endpoint_tool.py
+++ b/courtlistener/mcp/tools/call_endpoint_tool.py
@@ -32,7 +32,7 @@ class CallEndpointTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/courtlistener/mcp/tools/get_counts_tool.py
+++ b/courtlistener/mcp/tools/get_counts_tool.py
@@ -20,7 +20,7 @@ class GetCountsTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/courtlistener/mcp/tools/get_endpoint_item_tool.py
+++ b/courtlistener/mcp/tools/get_endpoint_item_tool.py
@@ -18,7 +18,7 @@ class GetEndpointItemTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/courtlistener/mcp/tools/get_more_results_tool.py
+++ b/courtlistener/mcp/tools/get_more_results_tool.py
@@ -32,7 +32,7 @@ class GetMoreResultsTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=False,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/courtlistener/mcp/tools/read_document_tool.py
+++ b/courtlistener/mcp/tools/read_document_tool.py
@@ -45,7 +45,7 @@ class ReadDocumentTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/courtlistener/mcp/tools/resume_citation_analysis_tool.py
+++ b/courtlistener/mcp/tools/resume_citation_analysis_tool.py
@@ -32,7 +32,7 @@ class ResumeCitationAnalysisTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=False,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/courtlistener/mcp/tools/search_document_tool.py
+++ b/courtlistener/mcp/tools/search_document_tool.py
@@ -41,7 +41,7 @@ class SearchDocumentTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/courtlistener/mcp/tools/search_tool.py
+++ b/courtlistener/mcp/tools/search_tool.py
@@ -37,7 +37,7 @@ class SearchTool(MCPTool):
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
-        openWorldHint=True,
+        openWorldHint=False,
     )
 
     def get_input_schema(self) -> dict:

--- a/docs/mcp/tools/analyze_citations.md
+++ b/docs/mcp/tools/analyze_citations.md
@@ -45,7 +45,7 @@ Input should include exactly one of opinion_id or cluster_id.
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `true` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/docs/mcp/tools/call_endpoint.md
+++ b/docs/mcp/tools/call_endpoint.md
@@ -25,7 +25,7 @@ search endpoint and often include more detailed metadata.
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `true` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/docs/mcp/tools/get_counts.md
+++ b/docs/mcp/tools/get_counts.md
@@ -24,7 +24,7 @@ from a previous query if it is not available.
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `true` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/docs/mcp/tools/get_endpoint_item.md
+++ b/docs/mcp/tools/get_endpoint_item.md
@@ -21,7 +21,7 @@ Get an item by ID from a CourtListener API endpoint.
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `true` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/docs/mcp/tools/get_more_results.md
+++ b/docs/mcp/tools/get_more_results.md
@@ -24,7 +24,7 @@ Use this tool to continue paginating through results returned by the
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `false` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/docs/mcp/tools/read_document.md
+++ b/docs/mcp/tools/read_document.md
@@ -42,7 +42,7 @@ Input should include exactly one of opinion_id, recap_document_id, or cluster_id
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `true` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/docs/mcp/tools/resume_citation_analysis.md
+++ b/docs/mcp/tools/resume_citation_analysis.md
@@ -25,7 +25,7 @@ Takes the job_id and verifies the next batch.
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `false` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/docs/mcp/tools/search.md
+++ b/docs/mcp/tools/search.md
@@ -27,7 +27,7 @@ be useful here.
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `true` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/docs/mcp/tools/search_document.md
+++ b/docs/mcp/tools/search_document.md
@@ -37,7 +37,7 @@ Input should include exactly one of opinion_id, recap_document_id, or cluster_id
 | `readOnlyHint` | `true` |
 | `destructiveHint` | `false` |
 | `idempotentHint` | `true` |
-| `openWorldHint` | `true` |
+| `openWorldHint` | `false` |
 
 ## Parameters
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -31,13 +31,11 @@ DESTRUCTIVE_TOOLS = {
     "unsubscribe_from_docket_alert",
 }
 
-# Tools that operate on local data only (Pydantic schemas / eyecite);
-# no network calls are made, so openWorldHint=False.
-# Note: get_counts may make a lazy API call, so it is open-world.
-LOCAL_ONLY_TOOLS = {
-    "get_endpoint_schema",
-    "get_choices",
-    "extract_citations",
+OPEN_WORLD_TOOLS = {
+    "create_search_alert",
+    "delete_search_alert",
+    "subscribe_to_docket_alert",
+    "unsubscribe_from_docket_alert",
 }
 
 # Tools where repeating a call with the same arguments has an
@@ -118,18 +116,18 @@ class TestToolAnnotations:
             t = MCP_TOOLS[name].get_tool()
             assert t.annotations.idempotentHint is True, name
 
-    def test_local_tools_closed_world(self):
-        """Purely-local tools must have openWorldHint=False."""
-        for name in LOCAL_ONLY_TOOLS:
-            t = MCP_TOOLS[name].get_tool()
-            assert t.annotations.openWorldHint is False, name
-
-    def test_api_tools_open_world(self):
-        """All non-local tools must have openWorldHint=True."""
-        api_tools = set(MCP_TOOLS.keys()) - LOCAL_ONLY_TOOLS
-        for name in api_tools:
+    def test_open_world_tools(self):
+        """Alert tools must have openWorldHint=True."""
+        for name in OPEN_WORLD_TOOLS:
             t = MCP_TOOLS[name].get_tool()
             assert t.annotations.openWorldHint is True, name
+
+    def test_closed_world_tools(self):
+        """All other tools must have openWorldHint=False."""
+        closed_world_tools = set(MCP_TOOLS.keys()) - OPEN_WORLD_TOOLS
+        for name in closed_world_tools:
+            t = MCP_TOOLS[name].get_tool()
+            assert t.annotations.openWorldHint is False, name
 
 
 class TestToolTitles:


### PR DESCRIPTION
For tools that only make calls to the CourtListener API. We previously had these set to `True` under the understanding that CL API calls counts as `with an "open world" of external entities`. However, with the understanding that the CourtListener API is considered a first-party, private system, we are reverting this.