### PR TITLE
Fix `filter_class` 0 lookups being dropped

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,11 @@ Changes:
 - Cache a structured record of each verified token instead of a bare user hash, keyed by credential kind (`mcp:token_info:{kind}:{hmac}`), so an entry verified as one kind can never satisfy a lookup for another. Entries under the old `mcp:token_to_user:` namespace are ignored and re-verified once.
 - Token verification degrades to direct verification when the session store is unavailable, instead of turning a Redis blip into a 500 on every request.
 - Tools that only make CL API calls have been changed to have `openWorldHint=True`.
-- Fix search's `court` filter mislabeled as `MultipleChoiceFilter` when should be `MultipleChoiceStringFilter`.
 - Remove `comma_separated_pre_validator`, now redundant as `multiple_choice_validator` already splits on commas and whitespace, and splitting up front broke choice labels containing a comma (`"District Court, D. Alaska"`).
+
+Fix:
+- Fix `generate_models.py` dropping `filter_class` 0.
+- Fix search's `court` filter mislabeled as `MultipleChoiceFilter` when should be `MultipleChoiceStringFilter`.
 
 ### 1.2.0 - 2026-08-04
 

--- a/courtlistener/models/endpoints/aba_ratings.py
+++ b/courtlistener/models/endpoints/aba_ratings.py
@@ -9,7 +9,7 @@ from typing import Annotated, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter7
+from courtlistener.models.filters import Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -48,7 +48,7 @@ class AbaRatingsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),
@@ -68,7 +68,7 @@ class AbaRatingsEndpoint(Endpoint):
         ),
     ]
     year_rated: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="The year of the rating.",

--- a/courtlistener/models/endpoints/agreements.py
+++ b/courtlistener/models/endpoints/agreements.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -56,7 +56,7 @@ class AgreementsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/attorneys.py
+++ b/courtlistener/models/endpoints/attorneys.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -55,7 +55,7 @@ class AttorneysEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/audio.py
+++ b/courtlistener/models/endpoints/audio.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter6, Filter7
+from courtlistener.models.filters import Filter4, Filter6, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -94,7 +94,7 @@ class AudioEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),
@@ -142,7 +142,7 @@ class AudioEndpoint(Endpoint):
         ),
     ]
     stt_status: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="The status of the Speech to Text for this item?",

--- a/courtlistener/models/endpoints/clusters.py
+++ b/courtlistener/models/endpoints/clusters.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter6, Filter7
+from courtlistener.models.filters import Filter4, Filter6, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -139,7 +139,7 @@ class ClustersEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),
@@ -188,21 +188,21 @@ class ClustersEndpoint(Endpoint):
         BeforeValidator(choice_validator),
     ]
     scdb_votes_majority: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="the number of justices voting in the majority in a Supreme Court decision. More details at: http://scdb.wustl.edu/documentation.php?var=majVotes",
         ),
     ]
     scdb_votes_minority: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="the number of justices voting in the minority in a Supreme Court decision. More details at: http://scdb.wustl.edu/documentation.php?var=minVotes",
         ),
     ]
     citation_count: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="The number of times this document is cited by other opinion",

--- a/courtlistener/models/endpoints/courts.py
+++ b/courtlistener/models/endpoints/courts.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter6, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter6, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -118,7 +118,7 @@ class CourtsEndpoint(Endpoint):
         ),
     ]
     position: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="A dewey-decimal-style numeral indicating a hierarchical ordering of jurisdictions",

--- a/courtlistener/models/endpoints/debts.py
+++ b/courtlistener/models/endpoints/debts.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -57,7 +57,7 @@ class DebtsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/disclosure_positions.py
+++ b/courtlistener/models/endpoints/disclosure_positions.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -56,7 +56,7 @@ class DisclosurePositionsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/docket_entries.py
+++ b/courtlistener/models/endpoints/docket_entries.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter5, Filter6, Filter7
+from courtlistener.models.filters import Filter4, Filter5, Filter6, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -64,7 +64,7 @@ class DocketEntriesEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/dockets.py
+++ b/courtlistener/models/endpoints/dockets.py
@@ -9,7 +9,13 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter1, Filter2, Filter6, Filter7
+from courtlistener.models.filters import (
+    Filter1,
+    Filter2,
+    Filter4,
+    Filter6,
+    Filter7,
+)
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -204,7 +210,7 @@ class DocketsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/educations.py
+++ b/courtlistener/models/endpoints/educations.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -54,7 +54,7 @@ class EducationsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/financial_disclosures.py
+++ b/courtlistener/models/endpoints/financial_disclosures.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -87,7 +87,7 @@ class FinancialDisclosuresEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/gifts.py
+++ b/courtlistener/models/endpoints/gifts.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -54,7 +54,7 @@ class GiftsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/investments.py
+++ b/courtlistener/models/endpoints/investments.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -97,7 +97,7 @@ class InvestmentsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/non_investment_incomes.py
+++ b/courtlistener/models/endpoints/non_investment_incomes.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -57,7 +57,7 @@ class NonInvestmentIncomesEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/opinions.py
+++ b/courtlistener/models/endpoints/opinions.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter7
+from courtlistener.models.filters import Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -90,7 +90,7 @@ class OpinionsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/opinions_cited.py
+++ b/courtlistener/models/endpoints/opinions_cited.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
+from courtlistener.models.filters import Filter4
 from courtlistener.utils import (
     comma_separated_post_validator,
     multiple_choice_validator,
@@ -47,7 +48,7 @@ class OpinionsCitedEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/parties.py
+++ b/courtlistener/models/endpoints/parties.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -50,7 +50,7 @@ class PartiesEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/people.py
+++ b/courtlistener/models/endpoints/people.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter6, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter6, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -90,7 +90,7 @@ class PeopleEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/political_affiliations.py
+++ b/courtlistener/models/endpoints/political_affiliations.py
@@ -9,7 +9,7 @@ from typing import Annotated, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter6, Filter7
+from courtlistener.models.filters import Filter4, Filter6, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -61,7 +61,7 @@ class PoliticalAffiliationsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/positions.py
+++ b/courtlistener/models/endpoints/positions.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter6, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter6, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -142,7 +142,7 @@ class PositionsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),
@@ -555,14 +555,14 @@ class PositionsEndpoint(Endpoint):
         ),
     ]
     votes_yes: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="If votes are an integer, this is the number of votes in favor of a position.",
         ),
     ]
     votes_no: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="If votes are an integer, this is the number of votes opposed to a position.",

--- a/courtlistener/models/endpoints/recap_documents.py
+++ b/courtlistener/models/endpoints/recap_documents.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter3, Filter7
+from courtlistener.models.filters import Filter3, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -94,7 +94,7 @@ class RecapDocumentsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),
@@ -165,7 +165,7 @@ class RecapDocumentsEndpoint(Endpoint):
         ),
     ]
     ocr_status: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="The status of OCR processing on this item.",

--- a/courtlistener/models/endpoints/recap_query.py
+++ b/courtlistener/models/endpoints/recap_query.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter3, Filter7
+from courtlistener.models.filters import Filter3, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -51,7 +51,7 @@ class RecapQueryEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),
@@ -115,7 +115,7 @@ class RecapQueryEndpoint(Endpoint):
         ),
     ]
     ocr_status: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             json_schema_extra={

--- a/courtlistener/models/endpoints/reimbursements.py
+++ b/courtlistener/models/endpoints/reimbursements.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -59,7 +59,7 @@ class ReimbursementsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/retention_events.py
+++ b/courtlistener/models/endpoints/retention_events.py
@@ -9,7 +9,7 @@ from typing import Annotated, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter6, Filter7
+from courtlistener.models.filters import Filter4, Filter6, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -66,7 +66,7 @@ class RetentionEventsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),
@@ -128,14 +128,14 @@ class RetentionEventsEndpoint(Endpoint):
         BeforeValidator(choice_validator),
     ]
     votes_yes: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="If votes are an integer, this is the number of votes in favor of a position.",
         ),
     ]
     votes_no: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
             description="If votes are an integer, this is the number of votes opposed to a position.",

--- a/courtlistener/models/endpoints/schools.py
+++ b/courtlistener/models/endpoints/schools.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -49,7 +49,7 @@ class SchoolsEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/courtlistener/models/endpoints/spouse_incomes.py
+++ b/courtlistener/models/endpoints/spouse_incomes.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import AfterValidator, BeforeValidator, Field
 
 from courtlistener.models.endpoint import Endpoint
-from courtlistener.models.filters import Filter2, Filter7
+from courtlistener.models.filters import Filter2, Filter4, Filter7
 from courtlistener.utils import (
     choice_validator,
     comma_separated_post_validator,
@@ -53,7 +53,7 @@ class SpouseIncomesEndpoint(Endpoint):
         BeforeValidator(multiple_choice_validator),
     ]
     id: Annotated[
-        None | int,
+        None | int | Filter4,
         Field(
             None,
         ),

--- a/docs/api/endpoints/aba_ratings.md
+++ b/docs/api/endpoints/aba_ratings.md
@@ -37,6 +37,8 @@ Choices (7):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)
@@ -58,6 +60,8 @@ Lookups: `day`, `gt`, `gte`, `hour`, `lt`, `lte`, `minute`, `month`, `range`, `s
 integer
 
 The year of the rating.
+
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
 
 ### `rating`
 

--- a/docs/api/endpoints/agreements.md
+++ b/docs/api/endpoints/agreements.md
@@ -38,6 +38,8 @@ Choices (8):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/attorneys.md
+++ b/docs/api/endpoints/attorneys.md
@@ -40,6 +40,8 @@ Choices (10):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/audio.md
+++ b/docs/api/endpoints/audio.md
@@ -57,6 +57,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_modified`
 
 string (date-time)
@@ -104,6 +106,8 @@ Is audio for this item done processing?
 integer
 
 The status of the Speech to Text for this item?
+
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
 
 Choices (6):
 

--- a/docs/api/endpoints/clusters.md
+++ b/docs/api/endpoints/clusters.md
@@ -78,6 +78,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)
@@ -128,17 +130,23 @@ integer
 
 the number of justices voting in the majority in a Supreme Court decision. More details at: http://scdb.wustl.edu/documentation.php?var=majVotes
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `scdb_votes_minority`
 
 integer
 
 the number of justices voting in the minority in a Supreme Court decision. More details at: http://scdb.wustl.edu/documentation.php?var=minVotes
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `citation_count`
 
 integer
 
 The number of times this document is cited by other opinion
+
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
 
 ### `precedential_status`
 

--- a/docs/api/endpoints/courts.md
+++ b/docs/api/endpoints/courts.md
@@ -85,6 +85,8 @@ integer
 
 A dewey-decimal-style numeral indicating a hierarchical ordering of jurisdictions
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `start_date`
 
 string (date)

--- a/docs/api/endpoints/debts.md
+++ b/docs/api/endpoints/debts.md
@@ -39,6 +39,8 @@ Choices (9):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/disclosure_positions.md
+++ b/docs/api/endpoints/disclosure_positions.md
@@ -38,6 +38,8 @@ Choices (8):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/docket_entries.md
+++ b/docs/api/endpoints/docket_entries.md
@@ -45,6 +45,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `entry_number`
 
 integer

--- a/docs/api/endpoints/dockets.md
+++ b/docs/api/endpoints/dockets.md
@@ -92,6 +92,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_modified`
 
 string (date-time)

--- a/docs/api/endpoints/educations.md
+++ b/docs/api/endpoints/educations.md
@@ -39,6 +39,8 @@ Choices (9):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/financial_disclosures.md
+++ b/docs/api/endpoints/financial_disclosures.md
@@ -56,6 +56,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `person`
 
 integer

--- a/docs/api/endpoints/gifts.md
+++ b/docs/api/endpoints/gifts.md
@@ -39,6 +39,8 @@ Choices (9):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/investments.md
+++ b/docs/api/endpoints/investments.md
@@ -51,6 +51,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/non_investment_incomes.md
+++ b/docs/api/endpoints/non_investment_incomes.md
@@ -39,6 +39,8 @@ Choices (9):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/opinions.md
+++ b/docs/api/endpoints/opinions.md
@@ -62,6 +62,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_modified`
 
 string (date-time)

--- a/docs/api/endpoints/opinions_cited.md
+++ b/docs/api/endpoints/opinions_cited.md
@@ -35,6 +35,8 @@ Choices (5):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `citing_opinion`
 
 integer

--- a/docs/api/endpoints/parties.md
+++ b/docs/api/endpoints/parties.md
@@ -38,6 +38,8 @@ Choices (8):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/people.md
+++ b/docs/api/endpoints/people.md
@@ -65,6 +65,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/political_affiliations.md
+++ b/docs/api/endpoints/political_affiliations.md
@@ -43,6 +43,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/positions.md
+++ b/docs/api/endpoints/positions.md
@@ -72,6 +72,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `position_type`
 
 string
@@ -316,11 +318,15 @@ integer
 
 If votes are an integer, this is the number of votes in favor of a position.
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `votes_no`
 
 integer
 
 If votes are an integer, this is the number of votes opposed to a position.
+
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
 
 ### `how_selected`
 

--- a/docs/api/endpoints/recap_documents.md
+++ b/docs/api/endpoints/recap_documents.md
@@ -58,6 +58,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)
@@ -126,6 +128,8 @@ The ID used for a document in RECAP
 integer
 
 The status of OCR processing on this item.
+
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
 
 Choices (4):
 

--- a/docs/api/endpoints/recap_query.md
+++ b/docs/api/endpoints/recap_query.md
@@ -34,6 +34,8 @@ Choices (4):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)
@@ -86,6 +88,8 @@ string
 ### `ocr_status`
 
 integer
+
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
 
 Choices (4):
 

--- a/docs/api/endpoints/reimbursements.md
+++ b/docs/api/endpoints/reimbursements.md
@@ -43,6 +43,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/retention_events.md
+++ b/docs/api/endpoints/retention_events.md
@@ -45,6 +45,8 @@ Filter which fields are returned.
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `position`
 
 integer
@@ -95,11 +97,15 @@ integer
 
 If votes are an integer, this is the number of votes in favor of a position.
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `votes_no`
 
 integer
 
 If votes are an integer, this is the number of votes opposed to a position.
+
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
 
 ### `unopposed`
 

--- a/docs/api/endpoints/schools.md
+++ b/docs/api/endpoints/schools.md
@@ -37,6 +37,8 @@ Choices (7):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/docs/api/endpoints/spouse_incomes.md
+++ b/docs/api/endpoints/spouse_incomes.md
@@ -38,6 +38,8 @@ Choices (8):
 
 integer
 
+Lookups: `gt`, `gte`, `lt`, `lte`, `range`
+
 ### `date_created`
 
 string (date-time)

--- a/scripts/generate_models.py
+++ b/scripts/generate_models.py
@@ -811,7 +811,7 @@ def get_endpoint_data(use_cache: bool = True) -> dict[str, Any]:
         filter_class["types_str"] = " | ".join(filter_class["types"])
     for endpoint in endpoints.values():
         for endpoint_field in endpoint["fields"].values():
-            if endpoint_field.get("filter_class"):
+            if endpoint_field.get("filter_class") is not None:
                 endpoint_field["filter_class"] = filter_classes[
                     endpoint_field["filter_class"]
                 ]["class_name"]


### PR DESCRIPTION
A 0 index being treated as false that should have been an `is None` check in our `generate_models` script was dropping a set of lookup filters from endpoint schemas.