### PR TITLE
Add auth backend to infer token kind from headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 The following changes are not yet released, but are code complete:
 
+Features:
+- Accept a CourtListener API token as an MCP credential alongside OAuth, so clients that can't run an interactive OAuth flow (server-to-server backends, scripts) can connect. Send it as `Authorization: Token <api_token>`, the same scheme CourtListener's REST API uses. The scheme selects the credential type and is binding: `Bearer` is verified against OIDC userinfo only and `Token` against the CourtListener API.
+
 Changes:
 - Add `courtlistener/settings.py` with `get_api_base_url()`, now the single source of truth for the CourtListener API root.
 - Cache a structured record of each verified token instead of a bare user hash, keyed by credential kind (`mcp:token_info:{kind}:{hmac}`), so an entry verified as one kind can never satisfy a lookup for another. Entries under the old `mcp:token_to_user:` namespace are ignored and re-verified once.

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -23,6 +23,7 @@ It is the same data that powers [courtlistener.com](https://www.courtlistener.co
 - [Authentication](#authentication)
   - [OAuth 2.0](#oauth-20)
   - [CourtListener API token](#courtlistener-api-token)
+  - [What the server stores](#what-the-server-stores)
 - [Available tools](#available-tools)
 - [Usage notes and limits](#usage-notes-and-limits)
 - [Troubleshooting](#troubleshooting)

--- a/MCP_README.md
+++ b/MCP_README.md
@@ -21,6 +21,8 @@ It is the same data that powers [courtlistener.com](https://www.courtlistener.co
   - [Claude Code](#claude-code)
   - [Other MCP clients](#other-mcp-clients)
 - [Authentication](#authentication)
+  - [OAuth 2.0](#oauth-20)
+  - [CourtListener API token](#courtlistener-api-token)
 - [Available tools](#available-tools)
 - [Usage notes and limits](#usage-notes-and-limits)
 - [Troubleshooting](#troubleshooting)
@@ -49,7 +51,7 @@ Under the hood the server exposes a small set of focused tools (search, citation
 1. **A free CourtListener account.** Sign up at [courtlistener.com/register](https://www.courtlistener.com/register/). Accounts are free for individuals; the [terms of service](https://www.courtlistener.com/terms/) apply.
 2. **An MCP-capable client.** Anything that speaks MCP over Streamable HTTP with OAuth 2.0 will work. We test against Claude.ai, Claude Desktop, Claude Code, and Cursor.
 
-You do **not** need a separate API token to use the hosted server. Authentication is handled by signing in with your CourtListener account through your MCP client's OAuth flow.
+You do **not** need a separate API token to use the hosted server. Authentication is handled by signing in with your CourtListener account through your MCP client's OAuth flow. If your client can't run that flow — a server-to-server integration, say — you can present a CourtListener API token instead; see [Authentication](#authentication).
 
 ---
 
@@ -85,11 +87,17 @@ The first time you call a CourtListener tool, Claude Code will open a browser wi
 
 Any client that supports **Streamable HTTP transport** with **OAuth 2.0** can connect. The server publishes [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) protected-resource metadata that points clients at CourtListener as the authorization server, so most well-behaved clients can discover everything they need from the URL alone.
 
+Clients that can't run an interactive OAuth flow can send a CourtListener API token instead — see [Authentication](#authentication).
+
 For Cursor, Windsurf, and similar editors, look for an "Add MCP server" or "Custom MCP server" option in settings and use the URL above with HTTP transport.
 
 ---
 
 ## Authentication
+
+The server accepts two kinds of credential. Interactive clients should use OAuth; API tokens exist for clients that can't run a browser-based flow.
+
+### OAuth 2.0
 
 The server uses OAuth 2.0 with [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591), so individual users do not need to pre-register their MCP client with CourtListener. The flow is standard:
 
@@ -100,7 +108,25 @@ The server uses OAuth 2.0 with [Dynamic Client Registration](https://datatracker
 
 Tokens are short-lived; clients refresh them automatically. If a token is revoked or expires, the next request returns HTTP 401 with a `WWW-Authenticate` header and the client transparently re-runs the OAuth flow.
 
-The server is a thin proxy: it never stores your CourtListener credentials, and your access token is forwarded directly to the CourtListener REST API on each tool call. If you revoke the connection from your [CourtListener profile](https://www.courtlistener.com/profile/), all access stops immediately.
+### CourtListener API token
+
+If your client can't complete an interactive OAuth flow — a server-to-server backend, a script, a platform with no browser — send your CourtListener API token instead, using the same scheme the REST API uses:
+
+```
+Authorization: Token <your-CL-API-token>
+```
+
+Get one from your [profile settings](https://www.courtlistener.com/profile/api/). It doesn't expire and never rotates, which is what makes it workable for multi-instance deployments where sharing a rotating OAuth refresh token isn't practical.
+
+Three things to know:
+
+- **The scheme is binding.** `Token` is for API tokens, `Bearer` is for OAuth access tokens, and each credential is only ever checked against the issuer that could have minted it. Sending an API token as `Bearer` returns 401 rather than falling back.
+- **An API token grants full access to your CourtListener account's API surface**, including the alert and subscription tools. Treat it like a password: keep it out of source control, and regenerate it if it leaks.
+- **Session state is keyed to the credential.** Pagination cursors and citation jobs started under an API token aren't visible to the same person connected over OAuth, and vice versa. Regenerating your token likewise orphans that state — it expires within the hour regardless.
+
+### What the server stores
+
+The server is a thin proxy: it never stores your CourtListener credentials, and your credential is forwarded directly to the CourtListener REST API on each tool call. If you revoke the connection from your [CourtListener profile](https://www.courtlistener.com/profile/), all access stops immediately.
 
 ---
 
@@ -162,6 +188,9 @@ These tools modify your CourtListener account state. Your client should prompt y
 
 **The OAuth window won't open / sign-in loops.**
 Confirm that your client supports OAuth 2.0 with Dynamic Client Registration. Older versions of some clients only support API-key auth and won't work here. Update to the latest version.
+
+**Every request returns 401 with an API token.**
+Check the scheme: an API token goes out as `Authorization: Token <api_token>`, never `Bearer`, which is reserved for OAuth access tokens. If the scheme is right, confirm the token is current in your [profile settings](https://www.courtlistener.com/profile/api/) — regenerating a token invalidates the old one immediately.
 
 **Tools return "CourtListener rejected the request as unauthorized."**
 Your access token was revoked or expired mid-session. The next tool call will surface a clean 401 and your client should refresh automatically. If it doesn't, disconnect and reconnect the server in your client's settings.

--- a/courtlistener/mcp/auth.py
+++ b/courtlistener/mcp/auth.py
@@ -1,11 +1,22 @@
 import logging
+import time
 from typing import NoReturn
 
 import httpx
 from fastmcp.server.auth.auth import (
     AccessToken,
+    RemoteAuthProvider,
     TokenVerifier,
 )
+from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
+from mcp.server.auth.middleware.bearer_auth import (
+    AuthenticatedUser,
+    BearerAuthBackend,
+)
+from starlette.authentication import AuthCredentials
+from starlette.middleware import Middleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.requests import HTTPConnection
 
 from courtlistener.mcp.auth_types import ResolvedToken, TokenInfo, TokenKind
 from courtlistener.mcp.session import get_session, hmac_hex
@@ -47,15 +58,7 @@ async def verify_oauth_token(token: str) -> TokenInfo | None:
 
 
 async def verify_api_token(token: str) -> TokenInfo | None:
-    """Return token info if *token* is a valid CL API token.
-
-    Only 2xx counts as verified. Not 3xx: the API root 301s without the
-    trailing slash, and a redirect isn't an authentication. Not 429
-    either — DRF authenticates before it throttles, so *its* 429 would
-    prove the token is good, but CloudFront rate-limits in front of
-    Django and those 429s never reach it (#216), so an edge blip would
-    otherwise verify any string and cache it for the token TTL.
-    """
+    """Return token info if *token* is a valid CL API token."""
     try:
         async with httpx.AsyncClient(
             timeout=VERIFICATION_TIMEOUT_SECONDS
@@ -112,11 +115,13 @@ class CourtListenerTokenVerifier(TokenVerifier):
             required_scopes=["openid", "api"],
         )
 
-    async def verify_token(self, token: str) -> AccessToken | None:
+    async def verify_token(
+        self, token: str, kind: TokenKind = TokenKind.OAUTH
+    ) -> AccessToken | None:
+        """Verify *token* as a credential of *kind*."""
         if not token:
             return None
-        # Hardcoded to OAuth until we add API token support.
-        info = await resolve_token(token, kind=TokenKind.OAUTH)
+        info = await resolve_token(token, kind=kind)
         if info is None:
             return None
         return AccessToken(
@@ -129,3 +134,54 @@ class CourtListenerTokenVerifier(TokenVerifier):
                 "cached": info["cached"],
             },
         )
+
+
+class CourtListenerAuthBackend(BearerAuthBackend):
+    """Authenticate CL ``Token`` credentials as well as ``Bearer`` ones."""
+
+    token_verifier: CourtListenerTokenVerifier
+
+    def __init__(self, token_verifier: CourtListenerTokenVerifier) -> None:
+        super().__init__(token_verifier)
+
+    async def authenticate(self, conn: HTTPConnection):
+        auth_header = next(
+            (
+                conn.headers.get(key)
+                for key in conn.headers
+                if key.lower() == "authorization"
+            ),
+            None,
+        )
+        if not auth_header:
+            return None
+
+        scheme, _, credential = auth_header.partition(" ")
+        kind = TokenKind.from_scheme(scheme)
+        credential = credential.strip()
+        if kind is None or not credential:
+            return None
+        if kind is TokenKind.OAUTH:
+            return await super().authenticate(conn)
+
+        auth_info = await self.token_verifier.verify_token(credential, kind)
+        if not auth_info:
+            return None
+        if auth_info.expires_at and auth_info.expires_at < int(time.time()):
+            return None
+        return AuthCredentials(auth_info.scopes), AuthenticatedUser(auth_info)
+
+
+class CourtListenerAuthProvider(RemoteAuthProvider):
+    """``RemoteAuthProvider`` whose HTTP layer accepts both schemes."""
+
+    token_verifier: CourtListenerTokenVerifier
+
+    def get_middleware(self) -> list:
+        return [
+            Middleware(
+                AuthenticationMiddleware,
+                backend=CourtListenerAuthBackend(self.token_verifier),
+            ),
+            Middleware(AuthContextMiddleware),
+        ]

--- a/courtlistener/mcp/auth.py
+++ b/courtlistener/mcp/auth.py
@@ -127,6 +127,7 @@ class CourtListenerTokenVerifier(TokenVerifier):
         return AccessToken(
             token=token,
             client_id="courtlistener-mcp",
+            # API tokens lack OAuth scopes; echo the required set.
             scopes=list(self.required_scopes),
             claims={
                 "user_hash": info["user_hash"],
@@ -140,9 +141,6 @@ class CourtListenerAuthBackend(BearerAuthBackend):
     """Authenticate CL ``Token`` credentials as well as ``Bearer`` ones."""
 
     token_verifier: CourtListenerTokenVerifier
-
-    def __init__(self, token_verifier: CourtListenerTokenVerifier) -> None:
-        super().__init__(token_verifier)
 
     async def authenticate(self, conn: HTTPConnection):
         auth_header = next(
@@ -158,6 +156,7 @@ class CourtListenerAuthBackend(BearerAuthBackend):
 
         scheme, _, credential = auth_header.partition(" ")
         kind = TokenKind.from_scheme(scheme)
+        # Bearer stays byte-exact via the parent; only Token strips.
         credential = credential.strip()
         if kind is None or not credential:
             return None
@@ -178,6 +177,7 @@ class CourtListenerAuthProvider(RemoteAuthProvider):
     token_verifier: CourtListenerTokenVerifier
 
     def get_middleware(self) -> list:
+        # AuthProvider.get_middleware (fastmcp==3.4.0), backend swapped.
         return [
             Middleware(
                 AuthenticationMiddleware,

--- a/courtlistener/mcp/auth_types.py
+++ b/courtlistener/mcp/auth_types.py
@@ -11,6 +11,23 @@ class TokenKind(str, Enum):
     # Not cosmetic: used as token info cache key suffix.
     __str__ = str.__str__
 
+    @property
+    def scheme(self) -> str:
+        """The ``Authorization`` scheme this kind arrives under."""
+        return TOKEN_KIND_SCHEMES[self]
+
+    @classmethod
+    def from_scheme(cls, scheme: str) -> "TokenKind | None":
+        """Return the kind for an ``Authorization`` scheme, or ``None``."""
+        scheme = scheme.lower()
+        return next((kind for kind in cls if kind.scheme == scheme), None)
+
+
+TOKEN_KIND_SCHEMES = {
+    TokenKind.OAUTH: "bearer",
+    TokenKind.API: "token",
+}
+
 
 class TokenInfo(TypedDict):
     """A verified credential, as persisted in the session store."""

--- a/courtlistener/mcp/server.py
+++ b/courtlistener/mcp/server.py
@@ -1,10 +1,7 @@
 import base64
 
 from fastmcp import FastMCP
-from fastmcp.server.auth.auth import (
-    AuthProvider,
-    RemoteAuthProvider,
-)
+from fastmcp.server.auth.auth import AuthProvider
 from fastmcp.server.middleware.caching import ResponseCachingMiddleware
 from key_value.aio.stores.redis import RedisStore
 from mcp.types import Icon
@@ -19,7 +16,10 @@ from starlette.responses import (
 from starlette.routing import Route
 
 from courtlistener.mcp import settings
-from courtlistener.mcp.auth import CourtListenerTokenVerifier
+from courtlistener.mcp.auth import (
+    CourtListenerAuthProvider,
+    CourtListenerTokenVerifier,
+)
 from courtlistener.mcp.middleware import ToolHandlerMiddleware
 from courtlistener.mcp.prompts import GLOBAL_INSTRUCTIONS
 from courtlistener.mcp.settings import (
@@ -134,7 +134,7 @@ def build_auth() -> AuthProvider | None:
     """Return an ``AuthProvider`` when OAuth is configured, else ``None``."""
     if not settings.MCP_REQUIRE_OAUTH:
         return None
-    return RemoteAuthProvider(
+    return CourtListenerAuthProvider(
         token_verifier=CourtListenerTokenVerifier(base_url=MCP_BASE_URL),
         authorization_servers=[AnyHttpUrl(OAUTH_ISSUER)],
         base_url=MCP_BASE_URL,

--- a/courtlistener/mcp/tools/mcp_tool.py
+++ b/courtlistener/mcp/tools/mcp_tool.py
@@ -10,6 +10,7 @@ from jsonschema import Draft202012Validator
 from mcp.types import ToolAnnotations
 
 from courtlistener import CourtListener
+from courtlistener.mcp.auth_types import TokenKind
 from courtlistener.mcp.exceptions import ToolArgumentValidationError
 
 
@@ -21,22 +22,28 @@ class MCPTool:
         """Build a CourtListener client for the current request.
 
         Resolution order:
-        1. HTTP + OAuth mode: use the OAuth access token FastMCP
-           accepted via the pass-through verifier. Forwarded to the CL
-           API as ``Authorization: Bearer <jwt>``, which CL accepts
-           because ``OAuth2Authentication`` is registered in its
-           ``DEFAULT_AUTHENTICATION_CLASSES``.
-        2. HTTP + legacy mode: ``Authorization: Token <api_token>``
-           header (existing stdio-over-HTTP / testing path).
+        1. HTTP + auth mode: the credential FastMCP verified. Its
+           ``token_kind`` claim says which scheme CL expects it back
+           under — an OAuth access token as ``Authorization: Bearer
+           <jwt>`` (accepted because ``OAuth2Authentication`` is
+           registered in CL's ``DEFAULT_AUTHENTICATION_CLASSES``), or a
+           CL API token as ``Authorization: Token <api_token>``. Sending
+           either under the other scheme is rejected by CL.
+        2. HTTP + auth disabled: ``Authorization: Token <api_token>``
+           header (existing stdio-over-HTTP / testing path). Reachable
+           only while ``MCP_REQUIRE_OAUTH`` can turn the auth provider
+           off; with it on, the auth layer consumes the header first.
         3. stdio mode: ``COURTLISTENER_API_TOKEN`` env var, resolved
            by the ``CourtListener`` constructor.
         """
-        # 1. OAuth bearer token (HTTP + auth provider active)
+        # 1. Verified credential (HTTP + auth provider active)
         access_token = get_access_token()
         if access_token is not None:
+            if access_token.claims.get("token_kind") == TokenKind.API:
+                return CourtListener(api_token=access_token.token)
             return CourtListener(access_token=access_token.token)
 
-        # 2. Legacy "Token ..." header pass-through (no OAuth).
+        # 2. "Token ..." header pass-through (auth provider off).
         #    get_http_request() raises when called outside an HTTP
         #    request (e.g. stdio mode), so guard against that.
         try:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,9 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import AnyHttpUrl
 
 from courtlistener import CourtListener
 from courtlistener.mcp.auth import (
+    CourtListenerAuthBackend,
     CourtListenerTokenVerifier,
     resolve_token,
     verify_api_token,
@@ -87,15 +89,21 @@ class TestMCPToolGetClient:
 
         return MCPTool()
 
+    def _verified(self, token, **claims):
+        access_token = MagicMock()
+        access_token.token = token
+        access_token.claims = {"user_hash": "uh", **claims}
+        return access_token
+
     def test_oauth_bearer_when_access_token_present(self):
         """With a FastMCP AccessToken available, use Bearer auth."""
         tool = self._get_tool()
-        fake_token = MagicMock()
-        fake_token.token = "oauth-jwt"
         with (
             patch(
                 "courtlistener.mcp.tools.mcp_tool.get_access_token",
-                return_value=fake_token,
+                return_value=self._verified(
+                    "oauth-jwt", token_kind=TokenKind.OAUTH
+                ),
             ),
             patch(
                 "courtlistener.mcp.tools.mcp_tool.get_http_request"
@@ -105,6 +113,33 @@ class TestMCPToolGetClient:
         # The access-token path short-circuits before we touch the
         # HTTP request, so get_http_request should not be consulted.
         mock_req.assert_not_called()
+        assert cl.access_token == "oauth-jwt"
+        assert cl.client.headers["Authorization"] == "Bearer oauth-jwt"
+
+    def test_api_token_credential_uses_the_token_scheme(self):
+        """A verified API token must go back out under DRF's ``Token``
+        scheme — CL rejects an API token presented as Bearer."""
+        tool = self._get_tool()
+        with patch(
+            "courtlistener.mcp.tools.mcp_tool.get_access_token",
+            return_value=self._verified(
+                "cl-api-token", token_kind=TokenKind.API
+            ),
+        ):
+            cl = tool.get_client()
+        assert cl.api_token == "cl-api-token"
+        assert cl.access_token is None
+        assert cl.client.headers["Authorization"] == "Token cl-api-token"
+
+    def test_missing_kind_claim_defaults_to_bearer(self):
+        """Defensive: an AccessToken with no ``token_kind`` claim is
+        treated as OAuth rather than silently mis-schemed."""
+        tool = self._get_tool()
+        with patch(
+            "courtlistener.mcp.tools.mcp_tool.get_access_token",
+            return_value=self._verified("oauth-jwt"),
+        ):
+            cl = tool.get_client()
         assert cl.access_token == "oauth-jwt"
         assert cl.client.headers["Authorization"] == "Bearer oauth-jwt"
 
@@ -681,6 +716,256 @@ class TestUserHash:
             pytest.raises(ValueError, match="no credential"),
         ):
             user_hash(client)
+
+
+class TestTokenKindScheme:
+    """Each ``TokenKind`` carries the ``Authorization`` scheme it
+    arrives under; ``from_scheme`` is the lookup the auth backend uses
+    to route a request."""
+
+    def test_bearer_maps_to_oauth(self):
+        assert TokenKind.from_scheme("Bearer") is TokenKind.OAUTH
+
+    def test_token_maps_to_api(self):
+        assert TokenKind.from_scheme("Token") is TokenKind.API
+
+    def test_lookup_is_case_insensitive(self):
+        """RFC 7235 schemes are case-insensitive; clients vary."""
+        assert TokenKind.from_scheme("bearer") is TokenKind.OAUTH
+        assert TokenKind.from_scheme("TOKEN") is TokenKind.API
+
+    def test_unknown_scheme_returns_none(self):
+        assert TokenKind.from_scheme("Basic") is None
+        assert TokenKind.from_scheme("") is None
+
+    def test_scheme_attribute_does_not_disturb_the_value(self):
+        """The member's *value* feeds the cache key; the scheme rides
+        alongside without changing it."""
+        assert TokenKind.OAUTH.scheme == "bearer"
+        assert TokenKind.API.scheme == "token"
+        assert TokenKind.OAUTH.value == "oauth"
+        assert TokenKind.API.value == "api_token"
+        assert TokenKind("oauth") is TokenKind.OAUTH
+
+    @pytest.mark.parametrize("kind", list(TokenKind))
+    def test_every_kind_declares_a_scheme(self, kind):
+        """Adding a ``TokenKind`` without a scheme mapping would make
+        ``.scheme`` raise ``KeyError`` mid-request."""
+        assert kind.scheme
+
+
+class TestCourtListenerAuthBackend:
+    """The SDK's ``BearerAuthBackend`` drops anything that isn't
+    ``Bearer `` before the verifier sees it, so ``Token`` auth reads as
+    "no credentials" without this backend. The scheme selects the
+    credential kind and is binding — the inverted combinations are
+    rejected, not retried the other way."""
+
+    def _conn(self, auth_header):
+        conn = MagicMock()
+        conn.headers = (
+            {} if auth_header is None else {"authorization": auth_header}
+        )
+        return conn
+
+    def _backend(self, *, oauth=None, api=None):
+        """A backend over a verifier that records how it was asked."""
+        verifier = MagicMock()
+
+        # Mirrors the real verifier's signature: the kind defaults to
+        # OAUTH, which is what the parent's bearer path relies on when
+        # it calls ``verify_token(token)`` with no kind.
+        async def verify_token(token, kind=TokenKind.OAUTH):
+            return oauth if kind is TokenKind.OAUTH else api
+
+        verifier.verify_token = AsyncMock(side_effect=verify_token)
+        return CourtListenerAuthBackend(verifier), verifier
+
+    def _accepted(self):
+        token = MagicMock()
+        token.scopes = ["openid", "api"]
+        token.expires_at = None
+        token.client_id = "courtlistener-mcp"
+        return token
+
+    def test_token_scheme_verifies_as_an_api_credential(self):
+        backend, verifier = self._backend(api=self._accepted())
+        result = run(backend.authenticate(self._conn("Token cl-api-token")))
+        assert result is not None
+        verifier.verify_token.assert_awaited_once_with(
+            "cl-api-token", TokenKind.API
+        )
+
+    def test_bearer_scheme_stays_on_the_sdk_path(self):
+        """Bearer is handed to the parent so the SDK keeps owning the
+        OAuth path, and the SDK asks via the bare ``verify_token``
+        contract — no kind argument, so the OAUTH default applies."""
+        backend, verifier = self._backend(oauth=self._accepted())
+        result = run(backend.authenticate(self._conn("Bearer oauth-jwt")))
+        assert result is not None
+        verifier.verify_token.assert_awaited_once_with("oauth-jwt")
+
+    def test_scheme_match_is_case_insensitive(self):
+        """RFC 7235 credential schemes are case-insensitive, and clients
+        do vary (``token`` vs ``Token``)."""
+        backend, verifier = self._backend(api=self._accepted())
+        run(backend.authenticate(self._conn("token cl-api-token")))
+        verifier.verify_token.assert_awaited_once_with(
+            "cl-api-token", TokenKind.API
+        )
+
+    def test_rejected_api_token_yields_no_user(self):
+        backend, _ = self._backend(api=None)
+        assert run(backend.authenticate(self._conn("Token nope"))) is None
+
+    def test_expired_api_token_is_rejected(self):
+        expired = self._accepted()
+        expired.expires_at = 1
+        backend, _ = self._backend(api=expired)
+        assert run(backend.authenticate(self._conn("Token old"))) is None
+
+    def test_unsupported_scheme_is_rejected(self):
+        backend, verifier = self._backend(api=self._accepted())
+        assert run(backend.authenticate(self._conn("Basic abc123"))) is None
+        verifier.verify_token.assert_not_awaited()
+
+    def test_missing_header_is_rejected(self):
+        backend, verifier = self._backend(api=self._accepted())
+        assert run(backend.authenticate(self._conn(None))) is None
+        verifier.verify_token.assert_not_awaited()
+
+    def test_empty_credential_costs_no_round_trip(self):
+        backend, verifier = self._backend(api=self._accepted())
+        assert run(backend.authenticate(self._conn("Token "))) is None
+        verifier.verify_token.assert_not_awaited()
+
+
+class TestCourtListenerAuthProvider:
+    """The provider exists only to swap the auth backend. Everything
+    else — discovery routes, protected-resource metadata, the 401
+    challenge — must be inherited untouched."""
+
+    def _provider(self):
+        from courtlistener.mcp.auth import CourtListenerAuthProvider
+
+        return CourtListenerAuthProvider(
+            token_verifier=CourtListenerTokenVerifier(
+                base_url="https://mcp.example.test"
+            ),
+            authorization_servers=[AnyHttpUrl("https://example.test")],
+            base_url="https://mcp.example.test",
+        )
+
+    def test_installs_the_dual_scheme_backend(self):
+        from starlette.middleware.authentication import (
+            AuthenticationMiddleware,
+        )
+
+        middleware = self._provider().get_middleware()
+        auth_mw = middleware[0]
+        assert auth_mw.cls is AuthenticationMiddleware
+        assert isinstance(auth_mw.kwargs["backend"], CourtListenerAuthBackend)
+
+    def test_still_publishes_protected_resource_metadata(self):
+        routes = self._provider().get_routes(mcp_path="/")
+        paths = {getattr(r, "path", None) for r in routes}
+        assert "/.well-known/oauth-protected-resource" in paths
+
+
+class TestAuthOverHttp:
+    """End to end through FastMCP's middleware stack: the scheme has to
+    survive the whole chain, not just our backend in isolation."""
+
+    @pytest.fixture(autouse=True)
+    def fresh_session(self):
+        set_session(InMemorySession())
+        yield
+        set_session(None)
+
+    def _app(self):
+        from starlette.testclient import TestClient
+
+        import courtlistener.mcp.server as server_mod
+
+        mcp = server_mod.create_mcp_server(auth=server_mod.build_auth())
+        return TestClient(mcp.http_app(path="/"))
+
+    def _initialize(self, headers):
+        with self._app() as http_client:
+            return http_client.post(
+                "/",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-06-18",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "0"},
+                    },
+                },
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    **headers,
+                },
+            )
+
+    def _patch_verifiers(self, *, oauth_ok, api_ok):
+        info = {"user_hash": "uh"}
+        return (
+            patch(
+                "courtlistener.mcp.auth.verify_oauth_token",
+                new=AsyncMock(return_value=info if oauth_ok else None),
+            ),
+            patch(
+                "courtlistener.mcp.auth.verify_api_token",
+                new=AsyncMock(return_value=info if api_ok else None),
+            ),
+        )
+
+    def test_api_token_is_accepted(self):
+        oauth_patch, api_patch = self._patch_verifiers(
+            oauth_ok=False, api_ok=True
+        )
+        with oauth_patch, api_patch:
+            resp = self._initialize({"Authorization": "Token cl-api-token"})
+        assert resp.status_code == 200
+
+    def test_oauth_bearer_is_accepted(self):
+        oauth_patch, api_patch = self._patch_verifiers(
+            oauth_ok=True, api_ok=False
+        )
+        with oauth_patch, api_patch:
+            resp = self._initialize({"Authorization": "Bearer oauth-jwt"})
+        assert resp.status_code == 200
+
+    def test_api_token_sent_as_bearer_is_rejected(self):
+        """The inverted combination gets a 401, not a second chance:
+        a Bearer credential is only ever checked against userinfo."""
+        oauth_patch, api_patch = self._patch_verifiers(
+            oauth_ok=False, api_ok=True
+        )
+        with oauth_patch, api_patch:
+            resp = self._initialize({"Authorization": "Bearer cl-api-token"})
+        assert resp.status_code == 401
+
+    def test_oauth_token_sent_as_token_scheme_is_rejected(self):
+        """The other inversion: a ``Token`` credential is only ever
+        checked against CL's API."""
+        oauth_patch, api_patch = self._patch_verifiers(
+            oauth_ok=True, api_ok=False
+        )
+        with oauth_patch, api_patch:
+            resp = self._initialize({"Authorization": "Token oauth-jwt"})
+        assert resp.status_code == 401
+
+    def test_missing_credentials_still_get_the_oauth_challenge(self):
+        """Unauthenticated requests must keep advertising Bearer so
+        OAuth discovery is untouched — ``Token`` support is deliberately
+        not advertised in the RFC 6750 methods."""
+        resp = self._initialize({})
+        assert resp.status_code == 401
+        assert resp.headers["www-authenticate"].startswith("Bearer")
 
 
 class TestHealthEndpoint:

--- a/tests/test_mcp_sentry_exemptions.py
+++ b/tests/test_mcp_sentry_exemptions.py
@@ -64,12 +64,12 @@ class TestMiddlewareErrorClassification:
         assert "Rate limit exceeded" in str(excinfo.value)
         assert "donate.free.law" in str(excinfo.value)
 
-    def _fake_access_token(self, monkeypatch, cached):
+    def _fake_access_token(self, monkeypatch, cached, token_kind="oauth"):
         token = MagicMock()
         token.token = "tok"
         token.claims = {
             "user_hash": "uh",
-            "token_kind": "oauth",
+            "token_kind": token_kind,
             "cached": cached,
         }
         monkeypatch.setattr(
@@ -92,6 +92,23 @@ class TestMiddlewareErrorClassification:
             await _call_tool_raising(monkeypatch, error)
         assert "retry to re-authenticate" in str(excinfo.value)
         session.invalidate_token.assert_awaited_once_with("tok", "oauth")
+
+    @pytest.mark.asyncio
+    async def test_401_on_cached_api_token_invalidates_its_own_kind(
+        self, monkeypatch
+    ):
+        """The kind is part of the cache key, so a revoked API token
+        must be evicted under ``api_token`` — invalidating the OAuth
+        key would leave the stale entry serving requests for the full
+        TTL with no error anywhere (the self-heal would silently never
+        fire)."""
+        session = self._fake_access_token(
+            monkeypatch, cached=True, token_kind="api_token"
+        )
+        error = _api_error(401, {"detail": "Invalid token."})
+        with pytest.raises(SentryExemptToolError):
+            await _call_tool_raising(monkeypatch, error)
+        session.invalidate_token.assert_awaited_once_with("tok", "api_token")
 
     @pytest.mark.asyncio
     async def test_401_on_freshly_verified_token_reports(self, monkeypatch):


### PR DESCRIPTION
Fixes #253

Wires up the API-token auth path end to end. The `Authorization` scheme now selects the credential kind: `Bearer` → OAuth (verified via userinfo), `Token` → CL API token (verified via the API root). The scheme is binding — `Bearer <api_token>` and `Token <oauth_token>` are rejected rather than retried the other way, so each request costs at most one upstream verification call.

Mechanics:

- `CourtListenerAuthBackend` (extends the SDK's `BearerAuthBackend`): maps the scheme to a `TokenKind` and routes. Bearer requests are handed to the parent untouched, so the SDK keeps owning the OAuth path. This lives in a backend subclass because the SDK drops non-`Bearer` schemes before the verifier ever runs, and `get_middleware()` on the provider is the only seam where the backend is constructed.
- `CourtListenerAuthProvider` (extends `RemoteAuthProvider`): overrides only `get_middleware` to install the backend. Routes, protected-resource metadata, and the 401 challenge are inherited untouched — OAuth clients see no difference, and `Token` support is deliberately not advertised in the RFC 6750 metadata.
- `verify_token(token, kind=TokenKind.OAUTH)`: the defaulted param keeps it a compatible override of the `TokenVerifier` contract (the SDK's bare call means bearer means OAuth). The verified kind lands in claims as `token_kind`.
- `MCPTool.get_client` reads `token_kind` to forward the credential under the scheme CL expects (`Bearer` for access tokens, `Token` for API tokens).
- `TokenKind` now carries its scheme (`.scheme` property, `TokenKind.from_scheme()` lookup).
- Docs: MCP_README gains an API-token auth section; troubleshooting covers the wrong-scheme 401.

Tested beyond the unit suite with a full live flow against a local CourtListener (OAuth DCR → consent → PKCE exchange → tool calls; API-token initialize/tools/mutations; both inverted schemes rejected; revoked-token self-heal loop; unauthenticated Bearer challenge unchanged; mixed-scheme concurrency burst).