### PR TITLE
feat(sentry): bump default sentry sample rate

### DIFF
--- a/courtlistener/mcp/settings.py
+++ b/courtlistener/mcp/settings.py
@@ -38,7 +38,7 @@ MCP_SECRET_BYTES = MCP_SECRET_KEY.encode("utf-8")
 # Sentry config
 SENTRY_DSN = os.getenv("SENTRY_DSN") or None
 SENTRY_TRACES_SAMPLE_RATE = float(
-    os.getenv("SENTRY_TRACES_SAMPLE_RATE") or 0.02
+    os.getenv("SENTRY_TRACES_SAMPLE_RATE") or 0.05
 )
 
 # How long a verified token's info is cached.


### PR DESCRIPTION
Bump default sentry sample rate to 0.05

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
